### PR TITLE
fix: When you append a string to the workflow context, the value has multiple double quotes #307

### DIFF
--- a/powerjob-common/src/main/java/tech/powerjob/common/serialize/JsonUtils.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/serialize/JsonUtils.java
@@ -22,6 +22,9 @@ public class JsonUtils {
     }
 
     public static String toJSONString(Object obj) {
+        if (obj instanceof String) {
+            return (String) obj;
+        }
         try {
             return objectMapper.writeValueAsString(obj);
         }catch (Exception ignore) {
@@ -30,6 +33,9 @@ public class JsonUtils {
     }
 
     public static String toJSONStringUnsafe(Object obj) {
+        if (obj instanceof String) {
+            return (String) obj;
+        }
         try {
             return objectMapper.writeValueAsString(obj);
         }catch (Exception e) {


### PR DESCRIPTION
## What is the purpose of the change

fix bug #307 
