### PR TITLE
除了kryo，新增实现hessian2跨语言序列化，为后续跨语言版本的work使用

### DIFF
--- a/powerjob-common/pom.xml
+++ b/powerjob-common/pom.xml
@@ -21,6 +21,7 @@
         <okhttp.version>3.14.9</okhttp.version>
         <akka.version>2.6.12</akka.version>
         <kryo.version>5.0.4</kryo.version>
+        <hessian_lite.version>3.2.13</hessian_lite.version>
         <jackson.version>2.12.2</jackson.version>
         <junit.version>5.9.0</junit.version>
     </properties>
@@ -79,7 +80,12 @@
             <artifactId>kryo5</artifactId>
             <version>${kryo.version}</version>
         </dependency>
-
+        <!-- hessian2跨语言序列化框架 -->
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>hessian-lite</artifactId>
+            <version>${hessian_lite.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>

--- a/powerjob-common/src/main/java/tech/powerjob/common/serialize/Hessian2AkkaSerializer.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/serialize/Hessian2AkkaSerializer.java
@@ -1,0 +1,56 @@
+package tech.powerjob.common.serialize;
+
+import akka.serialization.JSerializer;
+import tech.powerjob.common.serialize.hessian2.Hessian2ObjectInput;
+import tech.powerjob.common.serialize.hessian2.Hessian2ObjectOutput;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.Serializable;
+
+/**
+ * Using custom serializers for akka-remote
+ * Kryo只支持java
+ * <a href="https://github.com/hessian-group">跨语言序列化反序列化框架</a>
+ * 为了方便集成跨语言版本的work 比如go或者csharp版本的work
+ *
+ * @author zdyu
+ * @since 2022/10/6
+ */
+public class Hessian2AkkaSerializer extends JSerializer implements Serializable {
+
+    @Override
+    public Object fromBinaryJava(byte[] bytes, Class<?> manifest) {
+        try (InputStream inputStream = new ByteArrayInputStream(bytes);
+             Hessian2ObjectInput input = new Hessian2ObjectInput(inputStream);
+        ) {
+            return input.readObject();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public int identifier() {
+        return 277778;
+    }
+
+    @Override
+    public byte[] toBinary(Object o) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             Hessian2ObjectOutput output = new Hessian2ObjectOutput(outputStream);
+        ) {
+            output.writeObject(o);
+            output.flushBuffer();
+            return outputStream.toByteArray();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public boolean includeManifest() {
+        return false;
+    }
+}

--- a/powerjob-common/src/main/java/tech/powerjob/common/serialize/hessian2/DefaultHessian2FactoryInitializer.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/serialize/hessian2/DefaultHessian2FactoryInitializer.java
@@ -1,0 +1,56 @@
+package tech.powerjob.common.serialize.hessian2;
+
+import com.alibaba.com.caucho.hessian.io.SerializerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author zdyu
+ * @since 2022/10/6
+ */
+public final class DefaultHessian2FactoryInitializer {
+    private static final Map<ClassLoader, SerializerFactory> CL_2_SERIALIZER_FACTORY = new ConcurrentHashMap<>();
+    private static volatile SerializerFactory SYSTEM_SERIALIZER_FACTORY;
+    private static final DefaultHessian2FactoryInitializer INSTANCE = new DefaultHessian2FactoryInitializer();
+
+    private DefaultHessian2FactoryInitializer() {
+    }
+
+    public static DefaultHessian2FactoryInitializer getInstance() {
+        return INSTANCE;
+    }
+
+    public SerializerFactory getSerializerFactory() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            // system classloader
+            if (SYSTEM_SERIALIZER_FACTORY == null) {
+                synchronized (DefaultHessian2FactoryInitializer.class) {
+                    if (SYSTEM_SERIALIZER_FACTORY == null) {
+                        SYSTEM_SERIALIZER_FACTORY = createSerializerFactory();
+                    }
+                }
+            }
+            return SYSTEM_SERIALIZER_FACTORY;
+        }
+
+        if (!CL_2_SERIALIZER_FACTORY.containsKey(classLoader)) {
+            synchronized (DefaultHessian2FactoryInitializer.class) {
+                if (!CL_2_SERIALIZER_FACTORY.containsKey(classLoader)) {
+                    SerializerFactory serializerFactory = createSerializerFactory();
+                    CL_2_SERIALIZER_FACTORY.put(classLoader, serializerFactory);
+                    return serializerFactory;
+                }
+            }
+        }
+        return CL_2_SERIALIZER_FACTORY.get(classLoader);
+    }
+
+    private SerializerFactory createSerializerFactory() {
+        Hessian2SerializerFactory hessian2SerializerFactory = new Hessian2SerializerFactory();
+        hessian2SerializerFactory.setAllowNonSerializable(false);
+        hessian2SerializerFactory.getClassFactory().allow("tech.powerjob.*");
+        return hessian2SerializerFactory;
+    }
+}

--- a/powerjob-common/src/main/java/tech/powerjob/common/serialize/hessian2/Hessian2ObjectInput.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/serialize/hessian2/Hessian2ObjectInput.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tech.powerjob.common.serialize.hessian2;
+
+import com.alibaba.com.caucho.hessian.io.Hessian2Input;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+
+/**
+ * Hessian2 object input implementation
+ * @author zdyu
+ * @since 2022/10/6
+ */
+public class Hessian2ObjectInput implements Closeable {
+    private final Hessian2Input mH2i;
+    private final DefaultHessian2FactoryInitializer hessian2FactoryInitializer;
+
+    public Hessian2ObjectInput(InputStream is) {
+        mH2i = new Hessian2Input(is);
+        hessian2FactoryInitializer = DefaultHessian2FactoryInitializer.getInstance();
+        mH2i.setSerializerFactory(hessian2FactoryInitializer.getSerializerFactory());
+    }
+
+    public Object readObject() throws IOException {
+        if (!mH2i.getSerializerFactory().getClassLoader().equals(Thread.currentThread().getContextClassLoader())) {
+            mH2i.setSerializerFactory(hessian2FactoryInitializer.getSerializerFactory());
+        }
+        return mH2i.readObject();
+    }
+
+    public <T> T readObject(Class<T> cls) throws IOException,
+            ClassNotFoundException {
+        if (!mH2i.getSerializerFactory().getClassLoader().equals(Thread.currentThread().getContextClassLoader())) {
+            mH2i.setSerializerFactory(hessian2FactoryInitializer.getSerializerFactory());
+        }
+        return (T) mH2i.readObject(cls);
+    }
+
+    public <T> T readObject(Class<T> cls, Type type) throws IOException, ClassNotFoundException {
+        if (!mH2i.getSerializerFactory().getClassLoader().equals(Thread.currentThread().getContextClassLoader())) {
+            mH2i.setSerializerFactory(hessian2FactoryInitializer.getSerializerFactory());
+        }
+        return readObject(cls);
+    }
+
+    /**
+     * Closes this stream and releases any system resources associated
+     * with it. If the stream is already closed then invoking this
+     * method has no effect.
+     *
+     * <p> As noted in {@link AutoCloseable#close()}, cases where the
+     * close may fail require careful attention. It is strongly advised
+     * to relinquish the underlying resources and to internally
+     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
+     * the {@code IOException}.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        mH2i.reset();
+    }
+}

--- a/powerjob-common/src/main/java/tech/powerjob/common/serialize/hessian2/Hessian2ObjectOutput.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/serialize/hessian2/Hessian2ObjectOutput.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tech.powerjob.common.serialize.hessian2;
+
+import com.alibaba.com.caucho.hessian.io.Hessian2Output;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Hessian2 object output implementation
+ * @author zdyu
+ * @since 2022/10/6
+ */
+public class Hessian2ObjectOutput  implements Closeable {
+
+    private final Hessian2Output mH2o;
+
+    public Hessian2ObjectOutput(OutputStream os) {
+        mH2o = new Hessian2Output(os);
+        mH2o.setSerializerFactory(DefaultHessian2FactoryInitializer.getInstance().getSerializerFactory());
+    }
+
+    public void writeObject(Object obj) throws IOException {
+        mH2o.writeObject(obj);
+    }
+    public void flushBuffer() throws IOException {
+        mH2o.flushBuffer();
+    }
+    /**
+     * Closes this stream and releases any system resources associated
+     * with it. If the stream is already closed then invoking this
+     * method has no effect.
+     *
+     * <p> As noted in {@link AutoCloseable#close()}, cases where the
+     * close may fail require careful attention. It is strongly advised
+     * to relinquish the underlying resources and to internally
+     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
+     * the {@code IOException}.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        mH2o.reset();
+    }
+}

--- a/powerjob-common/src/main/java/tech/powerjob/common/serialize/hessian2/Hessian2SerializerFactory.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/serialize/hessian2/Hessian2SerializerFactory.java
@@ -1,0 +1,14 @@
+package tech.powerjob.common.serialize.hessian2;
+
+import com.alibaba.com.caucho.hessian.io.SerializerFactory;
+
+/**
+ * @author zdyu
+ * @since 2022/10/6
+ */
+public class Hessian2SerializerFactory extends SerializerFactory {
+
+    public Hessian2SerializerFactory() {
+    }
+
+}


### PR DESCRIPTION
由于目前server和work用的都是kryo
无法扩展实现其他语言版本的work
新增实现hessian2跨语言序列化，为后续跨语言版本的work使用
比如 go ,csharp版本

