### PR TITLE
升级h2版本，修复安全漏洞

### DIFF
--- a/powerjob-official-processors/pom.xml
+++ b/powerjob-official-processors/pom.xml
@@ -22,7 +22,7 @@
         <logback.version>1.2.3</logback.version>
         <powerjob.worker.version>4.2.0</powerjob.worker.version>
         <spring.jdbc.version>5.2.9.RELEASE</spring.jdbc.version>
-        <h2.db.version>1.4.200</h2.db.version>
+        <h2.db.version>2.1.210</h2.db.version>
         <mysql.version>8.0.28</mysql.version>
 
         <!-- 全部 shade 化，避免依赖冲突 -->

--- a/powerjob-server/pom.xml
+++ b/powerjob-server/pom.xml
@@ -35,7 +35,7 @@
         <mssql-jdbc.version>7.4.1.jre8</mssql-jdbc.version>
         <db2-jdbc.version>11.5.0.0</db2-jdbc.version>
         <postgresql.version>42.2.14</postgresql.version>
-        <h2.db.version>1.4.200</h2.db.version>
+        <h2.db.version>2.1.210</h2.db.version>
 
         <zip4j.version>2.5.2</zip4j.version>
         <jgit.version>5.7.0.202003110725-r</jgit.version>

--- a/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/config/MultiDatasourceConfig.java
+++ b/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/config/MultiDatasourceConfig.java
@@ -23,7 +23,7 @@ import java.io.File;
 public class MultiDatasourceConfig {
 
     private static final String H2_DRIVER_CLASS_NAME = "org.h2.Driver";
-    private static final String H2_JDBC_URL_PATTERN = "jdbc:h2:file:%spowerjob_server_db";
+    private static final String H2_JDBC_URL_PATTERN = "jdbc:h2:file:%spowerjob_server_db;mode=LEGACY";
     private static final int H2_MIN_SIZE = 4;
     private static final int H2_MAX_ACTIVE_SIZE = 10;
 

--- a/powerjob-worker/pom.xml
+++ b/powerjob-worker/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <spring.version>5.3.23</spring.version>
         <powerjob.common.version>4.2.0</powerjob.common.version>
-        <h2.db.version>1.4.200</h2.db.version>
+        <h2.db.version>2.1.210</h2.db.version>
         <hikaricp.version>3.4.2</hikaricp.version>
         <junit.version>5.6.1</junit.version>
 

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/persistence/TaskDAOImpl.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/persistence/TaskDAOImpl.java
@@ -28,7 +28,7 @@ public class TaskDAOImpl implements TaskDAO {
         String delTableSQL = "drop table if exists task_info";
         // 感谢 Gitee 用户 @Linfly 反馈的 BUG
         // bigint(20) 与 Java Long 取值范围完全一致
-        String createTableSQL = "create table task_info (task_id varchar(255), instance_id bigint(20), sub_instance_id bigint(20), task_name varchar(255), task_content blob, address varchar(255), status int(5), result text, failed_cnt int(11), created_time bigint(20), last_modified_time bigint(20), last_report_time bigint(20), unique KEY pkey (instance_id, task_id))";
+        String createTableSQL = "create table task_info (task_id varchar(255), instance_id bigint, sub_instance_id bigint, task_name varchar(255), task_content blob, address varchar(255), status int, result text, failed_cnt int, created_time bigint, last_modified_time bigint, last_report_time bigint, constraint pkey unique(instance_id, task_id))";
 
         try (Connection conn = connectionFactory.getConnection(); Statement stat = conn.createStatement()) {
             stat.execute(delTableSQL);


### PR DESCRIPTION
#### 修复的问题：
h2的2.1.210之前的版本存在安全漏洞，详见：https://github.com/advisories/GHSA-45hx-wfhj-473x
#### 升级版本后代码改动：
1. 升级后规范了语法，原先建表语法报错，对原先sql改动适配官方语法。
2. server升级后任务实例运行时日志新增记录时报错，在jdbc url后新增;mode=LEGACY，可以兼容以前版本的h2所允许的sql,类似问题：https://github.com/jOOQ/jOOQ/issues/12802