### PR TITLE
在原有的工作节点标签和地址过滤基础上添加工作节点特征匹配功能

### DIFF
--- a/powerjob-common/src/main/java/tech/powerjob/common/request/WorkerHeartbeat.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/request/WorkerHeartbeat.java
@@ -50,6 +50,10 @@ public class WorkerHeartbeat implements PowerSerializable {
      */
     private String tag;
     /**
+     * worker 特征表
+     */
+    private List<String> features;
+    /**
      * 客户端名称
      */
     private String client;

--- a/powerjob-server/powerjob-server-common/src/main/java/tech/powerjob/server/common/module/WorkerInfo.java
+++ b/powerjob-server/powerjob-server-common/src/main/java/tech/powerjob/server/common/module/WorkerInfo.java
@@ -28,6 +28,8 @@ public class WorkerInfo {
 
     private String tag;
 
+    private List<String> features;
+
     private int lightTaskTrackerNum;
 
     private int heavyTaskTrackerNum;
@@ -48,6 +50,7 @@ public class WorkerInfo {
         protocol = workerHeartbeat.getProtocol();
         client = workerHeartbeat.getClient();
         tag = workerHeartbeat.getTag();
+        features = workerHeartbeat.getFeatures();
         systemMetrics = workerHeartbeat.getSystemMetrics();
         containerInfos = workerHeartbeat.getContainerInfos();
 

--- a/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/handler/AbWorkerRequestHandler.java
+++ b/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/handler/AbWorkerRequestHandler.java
@@ -68,6 +68,7 @@ public abstract class AbWorkerRequestHandler implements IWorkerRequestHandler {
                 .setVersion(heartbeat.getVersion())
                 .setProtocol(heartbeat.getProtocol())
                 .setTag(heartbeat.getTag())
+                .setFeatures(heartbeat.getFeatures())
                 .setWorkerAddress(heartbeat.getWorkerAddress())
                 .setDelayMs(startMs - heartbeat.getHeartbeatTime())
                 .setScore(heartbeat.getSystemMetrics().getScore());

--- a/powerjob-server/powerjob-server-extension/src/main/java/tech/powerjob/server/extension/defaultimpl/workerfilter/DesignatedWorkerFilter.java
+++ b/powerjob-server/powerjob-server-extension/src/main/java/tech/powerjob/server/extension/defaultimpl/workerfilter/DesignatedWorkerFilter.java
@@ -9,6 +9,7 @@ import tech.powerjob.server.common.module.WorkerInfo;
 import tech.powerjob.server.extension.WorkerFilter;
 import tech.powerjob.server.persistence.remote.model.JobInfoDO;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -37,6 +38,19 @@ public class DesignatedWorkerFilter implements WorkerFilter {
             if (tagOrAddress.equals(workerInfo.getTag()) || tagOrAddress.equals(workerInfo.getAddress())) {
                 return false;
             }
+        }
+        //支持工作节点特征匹配 允许工作节点支持多特征，比如工作节点支持datax和支持shell
+        List<String> features = workerInfo.getFeatures();
+        if (features != null) {
+            //工作节点 满足所有特征
+            boolean hashAllFeature = true;
+            for (String tagOrAddress : designatedWorkersSet) {
+                if (!features.contains(tagOrAddress)) {
+                    hashAllFeature = false;
+                    break;
+                }
+            }
+            return !hashAllFeature;
         }
 
         return true;

--- a/powerjob-server/powerjob-server-monitor/src/main/java/tech/powerjob/server/monitor/events/w2s/WorkerHeartbeatEvent.java
+++ b/powerjob-server/powerjob-server-monitor/src/main/java/tech/powerjob/server/monitor/events/w2s/WorkerHeartbeatEvent.java
@@ -5,6 +5,8 @@ import lombok.experimental.Accessors;
 import tech.powerjob.server.common.SJ;
 import tech.powerjob.server.monitor.Event;
 
+import java.util.List;
+
 /**
  * worker 心跳事件监控
  *
@@ -25,6 +27,7 @@ public class WorkerHeartbeatEvent implements Event {
     private String protocol;
 
     private String tag;
+    private List<String> features;
     private String workerAddress;
     /**
      * worker 上报时间与 server 之间的延迟
@@ -39,6 +42,6 @@ public class WorkerHeartbeatEvent implements Event {
 
     @Override
     public String message() {
-        return SJ.MONITOR_JOINER.join(appName, appId, version, protocol, tag, workerAddress, delayMs, score);
+        return SJ.MONITOR_JOINER.join(appName, appId, version, protocol, tag, features,workerAddress, delayMs, score);
     }
 }

--- a/powerjob-worker-agent/src/main/java/tech/powerjob/agent/MainApplication.java
+++ b/powerjob-worker-agent/src/main/java/tech/powerjob/agent/MainApplication.java
@@ -43,6 +43,8 @@ public class MainApplication implements Runnable {
     @Option(names = {"-t", "--tag"}, description = "worker-agent's tag")
     private String tag;
 
+    @Option(names = {"-f", "--features"}, description = "worker-agent's features")
+    private String features;
     public static void main(String[] args) {
         CommandLine commandLine = new CommandLine(new MainApplication());
         commandLine.execute(args);
@@ -60,6 +62,7 @@ public class MainApplication implements Runnable {
             cfg.setStoreStrategy(StoreStrategy.MEMORY.name().equals(storeStrategy) ? StoreStrategy.MEMORY : StoreStrategy.DISK);
             cfg.setMaxResultLength(length);
             cfg.setTag(tag);
+            cfg.setFeatures(Splitter.on(",").splitToList(features));
             cfg.setProtocol(Protocol.of(protocol));
 
             PowerJobWorker worker = new PowerJobWorker(cfg);

--- a/powerjob-worker-agent/src/main/java/tech/powerjob/agent/MainApplication.java
+++ b/powerjob-worker-agent/src/main/java/tech/powerjob/agent/MainApplication.java
@@ -62,7 +62,9 @@ public class MainApplication implements Runnable {
             cfg.setStoreStrategy(StoreStrategy.MEMORY.name().equals(storeStrategy) ? StoreStrategy.MEMORY : StoreStrategy.DISK);
             cfg.setMaxResultLength(length);
             cfg.setTag(tag);
-            cfg.setFeatures(Splitter.on(",").splitToList(features));
+            if(features!=null){
+                cfg.setFeatures(Splitter.on(",").splitToList(features));
+            }
             cfg.setProtocol(Protocol.of(protocol));
 
             PowerJobWorker worker = new PowerJobWorker(cfg);

--- a/powerjob-worker-samples/src/main/resources/application.properties
+++ b/powerjob-worker-samples/src/main/resources/application.properties
@@ -6,7 +6,7 @@ powerjob.worker.enabled=true
 # Transport port, default is 27777
 powerjob.worker.port=27777
 # Application name, used for grouping applications. Recommend to set the same value as project name.
-powerjob.worker.app-name=test
+powerjob.worker.app-name=powerjob-worker-samples
 # Address of PowerJob-server node(s). Ip:port or domain. Multiple addresses should be separated with comma.
 powerjob.worker.server-address=127.0.0.1:7700,127.0.0.1:7701
 # transport protocol between server and worker

--- a/powerjob-worker-samples/src/main/resources/application.properties
+++ b/powerjob-worker-samples/src/main/resources/application.properties
@@ -6,7 +6,7 @@ powerjob.worker.enabled=true
 # Transport port, default is 27777
 powerjob.worker.port=27777
 # Application name, used for grouping applications. Recommend to set the same value as project name.
-powerjob.worker.app-name=powerjob-worker-samples
+powerjob.worker.app-name=test
 # Address of PowerJob-server node(s). Ip:port or domain. Multiple addresses should be separated with comma.
 powerjob.worker.server-address=127.0.0.1:7700,127.0.0.1:7701
 # transport protocol between server and worker
@@ -17,3 +17,5 @@ powerjob.worker.store-strategy=disk
 powerjob.worker.max-result-length=4096
 # Max length of appended workflow context . Appended workflow context value that is longer than the value will be ignore.
 powerjob.worker.max-appended-wf-context-length=4096
+# worker features
+powerjob.worker.features=datax,shell,python

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobAutoConfiguration.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobAutoConfiguration.java
@@ -80,6 +80,8 @@ public class PowerJobAutoConfiguration {
 
         config.setTag(worker.getTag());
 
+        config.setFeatures(Arrays.asList(worker.getFeatures().split(",")));
+
         config.setMaxHeavyweightTaskNum(worker.getMaxHeavyweightTaskNum());
 
         config.setMaxLightweightTaskNum(worker.getMaxLightweightTaskNum());

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobProperties.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobProperties.java
@@ -157,6 +157,7 @@ public class PowerJobProperties {
         private int maxAppendedWfContextLength = 8192;
 
         private String tag;
+        private String features;
         /**
          * Max numbers of LightTaskTacker
          */

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/PowerJobWorker.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/PowerJobWorker.java
@@ -78,6 +78,7 @@ public class PowerJobWorker {
             } else {
                 log.warn("[PowerJobWorker] using TestMode now, it's dangerous if this is production env.");
             }
+            log.debug("config.getFeatures()："+config.getFeatures());
 
             // 初始化元数据
             String workerAddress = NetUtils.getLocalHost() + ":" + config.getPort();
@@ -128,6 +129,7 @@ public class PowerJobWorker {
             // 初始化定时任务
             workerRuntime.getExecutorManager().getCoreExecutor().scheduleAtFixedRate(new WorkerHealthReporter(workerRuntime), 0, config.getHealthReportInterval(), TimeUnit.SECONDS);
             workerRuntime.getExecutorManager().getCoreExecutor().scheduleWithFixedDelay(omsLogHandler.logSubmitter, 0, 5, TimeUnit.SECONDS);
+
 
             log.info("[PowerJobWorker] PowerJobWorker initialized successfully, using time: {}, congratulations!", stopwatch);
         }catch (Exception e) {

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/background/WorkerHealthReporter.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/background/WorkerHealthReporter.java
@@ -55,6 +55,7 @@ public class WorkerHealthReporter implements Runnable {
         heartbeat.setProtocol(workerRuntime.getWorkerConfig().getProtocol().name());
         heartbeat.setClient("KingPenguin");
         heartbeat.setTag(workerRuntime.getWorkerConfig().getTag());
+        heartbeat.setFeatures(workerRuntime.getWorkerConfig().getFeatures());
 
         // 上报 Tracker 数量
         heartbeat.setLightTaskTrackerNum(LightTaskTrackerManager.currentTaskTrackerSize());

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/common/PowerJobWorkerConfig.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/common/PowerJobWorkerConfig.java
@@ -77,6 +77,10 @@ public class PowerJobWorkerConfig {
 
     private String tag;
     /**
+     * worker features
+     */
+    private List<String> features;
+    /**
      * Max numbers of LightTaskTacker
      */
     private Integer maxLightweightTaskNum = 1024;


### PR DESCRIPTION
## 支持工作节点特征匹配

- 此功能用于防止工作节点环境不满足造成任务处理失败问题。例如 某个任务要求工作节点有datax和python等等环境支持，或要求有某个自定义任务处理器。

- 此功能不能严格校验是否满足环境要求。需要自己定义工作节点有那些特征，任务需要那些特征。

## 使用方法步骤：
1. 工作节点配置自定义特征表例如：powerjob.worker.features=datax,shell,python
2. 创建任务时设置任务的designatedWorkers 例如：python,datax
3. 任务执行时，如果工作节点的tag和address都不匹配（不时用这两个功能时），开始匹配工作节点特征表。
   要求工作节点的特征表能够满足designatedWorkers的所有特征要求，多个使用逗号分割