### PR TITLE
调度方式Spring（方法形式）新增

### DIFF
--- a/powerjob-worker-samples/src/main/java/tech/powerjob/samples/tester/SpringMethodProcessorService.java
+++ b/powerjob-worker-samples/src/main/java/tech/powerjob/samples/tester/SpringMethodProcessorService.java
@@ -1,0 +1,17 @@
+package tech.powerjob.samples.tester;
+
+import org.springframework.stereotype.Component;
+import tech.powerjob.worker.annotation.PowerJob;
+import tech.powerjob.worker.core.processor.TaskContext;
+import tech.powerjob.worker.log.OmsLogger;
+
+@Component
+public class SpringMethodProcessorService {
+
+    @PowerJob("test")
+    public void test(TaskContext context) {
+        OmsLogger omsLogger = context.getOmsLogger();
+        omsLogger.warn("测试日志");
+        System.out.println("测试执行");
+    }
+}

--- a/powerjob-worker-samples/src/main/java/tech/powerjob/samples/tester/SpringMethodProcessorService.java
+++ b/powerjob-worker-samples/src/main/java/tech/powerjob/samples/tester/SpringMethodProcessorService.java
@@ -9,9 +9,17 @@ import tech.powerjob.worker.log.OmsLogger;
 public class SpringMethodProcessorService {
 
     @PowerJob("test")
-    public void test(TaskContext context) {
+    public String test(TaskContext context) {
         OmsLogger omsLogger = context.getOmsLogger();
         omsLogger.warn("测试日志");
-        System.out.println("测试执行");
+        return null;
+    }
+
+
+    @PowerJob("test1")
+    public String test1(TaskContext context) {
+        OmsLogger omsLogger = context.getOmsLogger();
+        omsLogger.warn("测试日志");
+        return "测试日志";
     }
 }

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/PowerJobSpringWorker.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/PowerJobSpringWorker.java
@@ -8,6 +8,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import tech.powerjob.worker.common.PowerJobWorkerConfig;
 import tech.powerjob.worker.extension.processor.ProcessorFactory;
+import tech.powerjob.worker.processor.impl.BuildInSpringMethodProcessorFactory;
 import tech.powerjob.worker.processor.impl.BuiltInSpringProcessorFactory;
 
 import java.util.Collections;
@@ -43,12 +44,14 @@ public class PowerJobSpringWorker implements ApplicationContextAware, Initializi
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         BuiltInSpringProcessorFactory springProcessorFactory = new BuiltInSpringProcessorFactory(applicationContext);
 
+        BuildInSpringMethodProcessorFactory springMethodProcessorFactory = new BuildInSpringMethodProcessorFactory(applicationContext);
         // append BuiltInSpringProcessorFactory
 
         List<ProcessorFactory> processorFactories = Lists.newArrayList(
                 Optional.ofNullable(config.getProcessorFactoryList())
                         .orElse(Collections.emptyList()));
         processorFactories.add(springProcessorFactory);
+        processorFactories.add(springMethodProcessorFactory);
         config.setProcessorFactoryList(processorFactories);
     }
 

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/annotation/PowerJob.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/annotation/PowerJob.java
@@ -1,0 +1,22 @@
+package tech.powerjob.worker.annotation;
+
+
+import java.lang.annotation.*;
+
+/**
+ * 方法级别的power-job调度
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface PowerJob {
+
+
+    /**
+     * handler name
+     */
+    String value();
+
+
+
+}

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/processor/MethodBasicProcessor.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/processor/MethodBasicProcessor.java
@@ -1,0 +1,25 @@
+package tech.powerjob.worker.processor;
+
+import tech.powerjob.worker.core.processor.ProcessResult;
+import tech.powerjob.worker.core.processor.TaskContext;
+import tech.powerjob.worker.core.processor.sdk.BasicProcessor;
+
+import java.lang.reflect.Method;
+
+public class MethodBasicProcessor implements BasicProcessor {
+
+    private final Object bean;
+
+    private final Method method;
+
+    public MethodBasicProcessor(Object bean, Method method) {
+        this.bean = bean;
+        this.method = method;
+    }
+
+    @Override
+    public ProcessResult process(TaskContext context) throws Exception {
+        method.invoke(bean,context);
+        return new ProcessResult(true);
+    }
+}

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/processor/MethodBasicProcessor.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/processor/MethodBasicProcessor.java
@@ -1,5 +1,6 @@
 package tech.powerjob.worker.processor;
 
+import tech.powerjob.common.serialize.JsonUtils;
 import tech.powerjob.worker.core.processor.ProcessResult;
 import tech.powerjob.worker.core.processor.TaskContext;
 import tech.powerjob.worker.core.processor.sdk.BasicProcessor;
@@ -19,7 +20,7 @@ public class MethodBasicProcessor implements BasicProcessor {
 
     @Override
     public ProcessResult process(TaskContext context) throws Exception {
-        method.invoke(bean,context);
-        return new ProcessResult(true);
+        Object result = method.invoke(bean, context);
+        return new ProcessResult(true, JsonUtils.toJSONString(result));
     }
 }

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/processor/impl/AbstractBuildInSpringProcessorFactory.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/processor/impl/AbstractBuildInSpringProcessorFactory.java
@@ -1,0 +1,65 @@
+package tech.powerjob.worker.processor.impl;
+
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import tech.powerjob.common.enums.ProcessorType;
+import tech.powerjob.worker.extension.processor.ProcessorFactory;
+
+import java.util.Set;
+
+@Slf4j
+public abstract class AbstractBuildInSpringProcessorFactory implements ProcessorFactory {
+
+    protected final ApplicationContext applicationContext;
+
+    protected AbstractBuildInSpringProcessorFactory(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public Set<String> supportTypes() {
+        return Sets.newHashSet(ProcessorType.BUILT_IN.name());
+    }
+
+    protected boolean checkCanLoad() {
+        try {
+            ApplicationContext.class.getClassLoader();
+            return applicationContext != null;
+        } catch (Throwable ignore) {
+        }
+        return false;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    protected static <T> T getBean(String className, ApplicationContext ctx) throws Exception {
+
+        // 0. 尝试直接用 Bean 名称加载
+        try {
+            final Object bean = ctx.getBean(className);
+            if (bean != null) {
+                return (T) bean;
+            }
+        } catch (Exception ignore) {
+        }
+
+        // 1. ClassLoader 存在，则直接使用 clz 加载
+        ClassLoader classLoader = ctx.getClassLoader();
+        if (classLoader != null) {
+            return (T) ctx.getBean(classLoader.loadClass(className));
+        }
+        // 2. ClassLoader 不存在(系统类加载器不可见)，尝试用类名称小写加载
+        String[] split = className.split("\\.");
+        String beanName = split[split.length - 1];
+        // 小写转大写
+        char[] cs = beanName.toCharArray();
+        cs[0] += 32;
+        String beanName0 = String.valueOf(cs);
+        log.warn("[SpringUtils] can't get ClassLoader from context[{}], try to load by beanName:{}", ctx, beanName0);
+        return (T) ctx.getBean(beanName0);
+    }
+
+
+
+}

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/processor/impl/BuildInSpringMethodProcessorFactory.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/processor/impl/BuildInSpringMethodProcessorFactory.java
@@ -1,0 +1,146 @@
+package tech.powerjob.worker.processor.impl;
+
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import tech.powerjob.common.enums.ProcessorType;
+import tech.powerjob.worker.annotation.PowerJob;
+import tech.powerjob.worker.extension.processor.ProcessorBean;
+import tech.powerjob.worker.extension.processor.ProcessorDefinition;
+import tech.powerjob.worker.extension.processor.ProcessorFactory;
+import tech.powerjob.worker.processor.MethodBasicProcessor;
+
+import java.lang.reflect.Method;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 内建的 SpringBean 处理器工厂，用于加载 Spring 管理Bean下的方法（使用PowerJob注解），非核心依赖
+ *
+ * @author wxp
+ * @since 2023/4/06
+ */
+
+@Slf4j
+public class BuildInSpringMethodProcessorFactory implements ProcessorFactory {
+
+    private final ApplicationContext applicationContext;
+
+    private static final List<String> jobHandlerRepository = new LinkedList<>();
+
+    private final static String DELIMITER = "#";
+
+
+    public BuildInSpringMethodProcessorFactory(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+
+    @Override
+    public Set<String> supportTypes() {
+        return Sets.newHashSet(ProcessorType.BUILT_IN.name());
+    }
+
+    @Override
+    public ProcessorBean build(ProcessorDefinition processorDefinition) {
+        try {
+            boolean canLoad = checkCanLoad();
+            if (!canLoad) {
+                log.info("[ProcessorFactory] can't find Spring env, this processor can't load by 'BuildInSpringMethodProcessorFactory'");
+                return null;
+            }
+            String processorInfo = processorDefinition.getProcessorInfo();
+            if (!processorInfo.contains(DELIMITER)) {
+                log.info("[ProcessorFactory] can't parse processorDefinition, this processor can't load by 'BuildInSpringMethodProcessorFactory'");
+                return null;
+            }
+            String[] split = processorInfo.split("#");
+            String methodName = split[1];
+            String className = split[0];
+            Object bean = getBean(className,applicationContext);
+            Method[] methods = bean.getClass().getDeclaredMethods();
+            for (Method method : methods) {
+                PowerJob powerJob = method.getAnnotation(PowerJob.class);
+                if (powerJob == null) {
+                    continue;
+                }
+                String name = powerJob.value();
+                //匹配到和页面定义相同的methodName
+                if (!name.equals(methodName)) {
+                    continue;
+                }
+                if (name.trim().length() == 0) {
+                    throw new RuntimeException("method-jobhandler name invalid, for[" + bean.getClass() + "#" + method.getName() + "] .");
+                }
+                if (containsJobHandler(name)) {
+                    throw new RuntimeException("jobhandler[" + name + "] naming conflicts.");
+                }
+                method.setAccessible(true);
+                registerJobHandler(methodName);
+
+                MethodBasicProcessor processor = new MethodBasicProcessor(bean, method);
+                return new ProcessorBean()
+                        .setProcessor(processor)
+                        .setClassLoader(processor.getClass().getClassLoader());
+            }
+        } catch (NoSuchBeanDefinitionException ignore) {
+            log.warn("[ProcessorFactory] can't find the processor in SPRING");
+        } catch (Throwable t) {
+            log.warn("[ProcessorFactory] load by BuiltInSpringProcessorFactory failed. If you are using Spring, make sure this bean was managed by Spring", t);
+        }
+        return null;
+
+    }
+
+
+    public static void registerJobHandler(String name) {
+        jobHandlerRepository.add(name);
+    }
+
+
+    private boolean containsJobHandler(String name) {
+        return jobHandlerRepository.contains(name);
+    }
+
+    private boolean checkCanLoad() {
+        try {
+            ApplicationContext.class.getClassLoader();
+            return applicationContext != null;
+        } catch (Throwable ignore) {
+        }
+        return false;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private static Object getBean(String className, ApplicationContext ctx) throws Exception {
+
+        // 0. 尝试直接用 Bean 名称加载
+        try {
+            final Object bean = ctx.getBean(className);
+            if (bean != null) {
+                return bean;
+            }
+        } catch (Exception ignore) {
+        }
+
+        // 1. ClassLoader 存在，则直接使用 clz 加载
+        ClassLoader classLoader = ctx.getClassLoader();
+        if (classLoader != null) {
+            return ctx.getBean(classLoader.loadClass(className));
+        }
+        // 2. ClassLoader 不存在(系统类加载器不可见)，尝试用类名称小写加载
+        String[] split = className.split("\\.");
+        String beanName = split[split.length - 1];
+        // 小写转大写
+        char[] cs = beanName.toCharArray();
+        cs[0] += 32;
+        String beanName0 = String.valueOf(cs);
+        log.warn("[SpringUtils] can't get ClassLoader from context[{}], try to load by beanName:{}", ctx, beanName0);
+        return ctx.getBean(beanName0);
+    }
+
+
+}

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/processor/impl/BuildInSpringMethodProcessorFactory.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/processor/impl/BuildInSpringMethodProcessorFactory.java
@@ -1,20 +1,16 @@
 package tech.powerjob.worker.processor.impl;
 
-import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
-import tech.powerjob.common.enums.ProcessorType;
 import tech.powerjob.worker.annotation.PowerJob;
 import tech.powerjob.worker.extension.processor.ProcessorBean;
 import tech.powerjob.worker.extension.processor.ProcessorDefinition;
-import tech.powerjob.worker.extension.processor.ProcessorFactory;
 import tech.powerjob.worker.processor.MethodBasicProcessor;
 
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 
 /**
  * 内建的 SpringBean 处理器工厂，用于加载 Spring 管理Bean下的方法（使用PowerJob注解），非核心依赖
@@ -24,9 +20,7 @@ import java.util.Set;
  */
 
 @Slf4j
-public class BuildInSpringMethodProcessorFactory implements ProcessorFactory {
-
-    private final ApplicationContext applicationContext;
+public class BuildInSpringMethodProcessorFactory extends AbstractBuildInSpringProcessorFactory {
 
     private static final List<String> jobHandlerRepository = new LinkedList<>();
 
@@ -34,14 +28,9 @@ public class BuildInSpringMethodProcessorFactory implements ProcessorFactory {
 
 
     public BuildInSpringMethodProcessorFactory(ApplicationContext applicationContext) {
-        this.applicationContext = applicationContext;
+        super(applicationContext);
     }
 
-
-    @Override
-    public Set<String> supportTypes() {
-        return Sets.newHashSet(ProcessorType.BUILT_IN.name());
-    }
 
     @Override
     public ProcessorBean build(ProcessorDefinition processorDefinition) {
@@ -91,7 +80,6 @@ public class BuildInSpringMethodProcessorFactory implements ProcessorFactory {
             log.warn("[ProcessorFactory] load by BuiltInSpringProcessorFactory failed. If you are using Spring, make sure this bean was managed by Spring", t);
         }
         return null;
-
     }
 
 
@@ -102,44 +90,6 @@ public class BuildInSpringMethodProcessorFactory implements ProcessorFactory {
 
     private boolean containsJobHandler(String name) {
         return jobHandlerRepository.contains(name);
-    }
-
-    private boolean checkCanLoad() {
-        try {
-            ApplicationContext.class.getClassLoader();
-            return applicationContext != null;
-        } catch (Throwable ignore) {
-        }
-        return false;
-    }
-
-
-    @SuppressWarnings("unchecked")
-    private static Object getBean(String className, ApplicationContext ctx) throws Exception {
-
-        // 0. 尝试直接用 Bean 名称加载
-        try {
-            final Object bean = ctx.getBean(className);
-            if (bean != null) {
-                return bean;
-            }
-        } catch (Exception ignore) {
-        }
-
-        // 1. ClassLoader 存在，则直接使用 clz 加载
-        ClassLoader classLoader = ctx.getClassLoader();
-        if (classLoader != null) {
-            return ctx.getBean(classLoader.loadClass(className));
-        }
-        // 2. ClassLoader 不存在(系统类加载器不可见)，尝试用类名称小写加载
-        String[] split = className.split("\\.");
-        String beanName = split[split.length - 1];
-        // 小写转大写
-        char[] cs = beanName.toCharArray();
-        cs[0] += 32;
-        String beanName0 = String.valueOf(cs);
-        log.warn("[SpringUtils] can't get ClassLoader from context[{}], try to load by beanName:{}", ctx, beanName0);
-        return ctx.getBean(beanName0);
     }
 
 

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/processor/impl/BuiltInSpringProcessorFactory.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/processor/impl/BuiltInSpringProcessorFactory.java
@@ -41,8 +41,12 @@ public class BuiltInSpringProcessorFactory implements ProcessorFactory {
                 log.info("[ProcessorFactory] can't find Spring env, this processor can't load by 'BuiltInSpringProcessorFactory'");
                 return null;
             }
-
-            BasicProcessor basicProcessor = getBean(processorDefinition.getProcessorInfo(), applicationContext);
+            String processorInfo = processorDefinition.getProcessorInfo();
+            //用于区分方法级别的参数
+            if (processorInfo.contains("#")) {
+                return null;
+            }
+            BasicProcessor basicProcessor = getBean(processorInfo, applicationContext);
             return new ProcessorBean()
                     .setProcessor(basicProcessor)
                     .setClassLoader(basicProcessor.getClass().getClassLoader());

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/processor/impl/BuiltInSpringProcessorFactory.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/processor/impl/BuiltInSpringProcessorFactory.java
@@ -19,17 +19,11 @@ import java.util.Set;
  * @since 2023/1/17
  */
 @Slf4j
-public class BuiltInSpringProcessorFactory implements ProcessorFactory {
+public class BuiltInSpringProcessorFactory extends AbstractBuildInSpringProcessorFactory {
 
-    private final ApplicationContext applicationContext;
 
     public BuiltInSpringProcessorFactory(ApplicationContext applicationContext) {
-        this.applicationContext = applicationContext;
-    }
-
-    @Override
-    public Set<String> supportTypes() {
-        return Sets.newHashSet(ProcessorType.BUILT_IN.name());
+        super(applicationContext);
     }
 
     @Override
@@ -59,42 +53,5 @@ public class BuiltInSpringProcessorFactory implements ProcessorFactory {
         return null;
     }
 
-    private boolean checkCanLoad() {
-        try {
-            ApplicationContext.class.getClassLoader();
-            return applicationContext != null;
-        } catch (Throwable ignore) {
-        }
-        return false;
-    }
-
-
-    @SuppressWarnings("unchecked")
-    private static <T> T getBean(String className, ApplicationContext ctx) throws Exception {
-
-        // 0. 尝试直接用 Bean 名称加载
-        try {
-            final Object bean = ctx.getBean(className);
-            if (bean != null) {
-                return (T) bean;
-            }
-        } catch (Exception ignore) {
-        }
-
-        // 1. ClassLoader 存在，则直接使用 clz 加载
-        ClassLoader classLoader = ctx.getClassLoader();
-        if (classLoader != null) {
-            return (T) ctx.getBean(classLoader.loadClass(className));
-        }
-        // 2. ClassLoader 不存在(系统类加载器不可见)，尝试用类名称小写加载
-        String[] split = className.split("\\.");
-        String beanName = split[split.length - 1];
-        // 小写转大写
-        char[] cs = beanName.toCharArray();
-        cs[0] += 32;
-        String beanName0 = String.valueOf(cs);
-        log.warn("[SpringUtils] can't get ClassLoader from context[{}], try to load by beanName:{}", ctx, beanName0);
-        return (T) ctx.getBean(beanName0);
-    }
 
 }


### PR DESCRIPTION
参考了XXL-JOB实现了spring方法方式的调度任务注册，致力于优化开发人员的代码，或可减少类的浪费

增加了@PowerJob注解，使用方式如下：
1. 开发人员在一个由springbean管理的类中新增方法，贴上注解 ， 并写入需要注册的方法 。 例如：@PowerJob("test")
![image](https://user-images.githubusercontent.com/46670766/230348030-8e27fad0-621f-4804-b111-aa33a02c8c7f.png)

2. 并且在web页面中新建任务时给全限定域名后面新增"#",然后写上需要注册的类即可。
![image](https://user-images.githubusercontent.com/46670766/230348309-930b5771-a435-4711-a38d-517be96998fb.png)



