### PR TITLE
Update DispatchService.java

### DIFF
--- a/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/DispatchService.java
+++ b/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/DispatchService.java
@@ -169,15 +169,14 @@ public class DispatchService {
         // 发送请求（不可靠，需要一个后台线程定期轮询状态）
         WorkerInfo taskTracker = suitableWorkers.get(0);
         String taskTrackerAddress = taskTracker.getAddress();
-
-        URL workerUrl = ServerURLFactory.dispatchJob2Worker(taskTrackerAddress);
-        transportService.tell(taskTracker.getProtocol(), workerUrl, req);
-        log.info("[Dispatcher-{}|{}] send schedule request to TaskTracker[protocol:{},address:{}] successfully: {}.", jobId, instanceId, taskTracker.getProtocol(), taskTrackerAddress, req);
-
         // 修改状态
         instanceInfoRepository.update4TriggerSucceed(instanceId, WAITING_WORKER_RECEIVE.getV(), current, taskTrackerAddress, now, instanceInfo.getStatus());
         // 装载缓存
         instanceMetadataService.loadJobInfo(instanceId, jobInfo);
+        
+        URL workerUrl = ServerURLFactory.dispatchJob2Worker(taskTrackerAddress);
+        transportService.tell(taskTracker.getProtocol(), workerUrl, req);
+        log.info("[Dispatcher-{}|{}] send schedule request to TaskTracker[protocol:{},address:{}] successfully: {}.", jobId, instanceId, taskTracker.getProtocol(), taskTrackerAddress, req);
     }
 
     private List<WorkerInfo> filterOverloadWorker(List<WorkerInfo> suitableWorkers) {


### PR DESCRIPTION
fit: #620 
解决 PowerJob 4.3.2 的samples中实例，因执行任务客户机返回结果，在任务Worker的address更新到instance库之前返回，导致InstanceManager更新时获取不到instance库的TrackerAddress的问题；

   
                    