### PR TITLE
获取主机网络连接信息时按索引从小到大排序，优先使用索引值小的网络接口。

### DIFF
--- a/powerjob-common/src/main/java/tech/powerjob/common/utils/NetUtils.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/utils/NetUtils.java
@@ -155,6 +155,9 @@ public class NetUtils {
             log.warn("[Net] findNetworkInterface failed", e);
         }
 
+        // sort by interface index, the smaller is preferred.
+        validNetworkInterfaces.sort(Comparator.comparingInt(NetworkInterface::getIndex));
+
         // Try to find the preferred one
         for (NetworkInterface networkInterface : validNetworkInterfaces) {
             if (isPreferredNetworkInterface(networkInterface)) {


### PR DESCRIPTION
获取主机网络连接信息时按索引从小到大排序，优先使用索引值小的网络接口。
选择索引值最小的网络接口的原因是，操作系统通常会将默认的网络接口分配给较小的索引。通过选择索引值最小的网络接口，更有可能获得与默认网络接口相关联的IP地址。