### PR TITLE
fix-[#676] Set notifyUserIds to null when empty the notify info of a …

### DIFF
--- a/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/service/impl/job/JobServiceImpl.java
+++ b/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/service/impl/job/JobServiceImpl.java
@@ -89,8 +89,12 @@ public class JobServiceImpl implements JobService {
         fillDefaultValue(jobInfoDO);
 
         // 转化报警用户列表
-        if (!CollectionUtils.isEmpty(request.getNotifyUserIds())) {
-            jobInfoDO.setNotifyUserIds(SJ.COMMA_JOINER.join(request.getNotifyUserIds()));
+        if (request.getNotifyUserIds() != null) {
+            if (request.getNotifyUserIds().size() == 0) {
+                jobInfoDO.setNotifyUserIds(null);
+            } else {
+                jobInfoDO.setNotifyUserIds(SJ.COMMA_JOINER.join(request.getNotifyUserIds()));
+            }
         }
         LifeCycle lifecycle = Optional.ofNullable(request.getLifeCycle()).orElse(LifeCycle.EMPTY_LIFE_CYCLE);
         jobInfoDO.setLifecycle(JSON.toJSONString(lifecycle));


### PR DESCRIPTION
Enable a empty-update operation for clearing the notifyUserIds of a job. #676 