### PR TITLE
新增可指定powerjob-server服务端地址配置；

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <lombok.version>1.18.12</lombok.version>
+        <lombok.version>1.18.28</lombok.version>
     </properties>
 
     <dependencies>

--- a/powerjob-server/powerjob-server-starter/src/main/resources/application.properties
+++ b/powerjob-server/powerjob-server-starter/src/main/resources/application.properties
@@ -18,5 +18,9 @@ oms.transporter.active.protocols=AKKA,HTTP
 oms.transporter.main.protocol=HTTP
 oms.akka.port=10086
 oms.http.port=10010
+
+# Specify server address, Default empty
+oms.transporter.server-address=
+
 # Prefix for all tables. Default empty string. Config if you have needs, i.e. pj_
 oms.table-prefix=


### PR DESCRIPTION
1. 新增服务端地址强制设定功能；
2. 解决powerjob-Server在docker容器下，返回容器ip导致执行器无法连接服务端；

复现方法：
1. 使用docker部署powerjob-Server服务；
2.使用本地运行执行器链接server服务时，会出现 10010端口链接失败，原因是调用该接口返回的是容器的ip地址；
3.测试接口：/server/acquire?protocol=HTTP&appId=1