### PR TITLE
fix: Memory overflow caused by mounting cloud disks

### DIFF
--- a/powerjob-worker/src/main/java/tech/powerjob/worker/common/utils/SystemInfoUtils.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/common/utils/SystemInfoUtils.java
@@ -68,7 +68,8 @@ public class SystemInfoUtils {
         }
 
         metrics.setDiskUsed(bytes2GB(total - free));
-        metrics.setDiskTotal(bytes2GB(total));
+        // 防止内存溢出导致total为负数,导致找不到worker实例
+        metrics.setDiskTotal(bytes2GB(total < 0 ? Long.MAX_VALUE >> 6 : total ));
         metrics.setDiskUsage(miniDouble(metrics.getDiskUsed() / metrics.getDiskTotal()));
     }
 


### PR DESCRIPTION
## What is the purpose of the change

worker在获取当前磁盘可用空间及总空间时,会使用getFreeSpace与getTotalSpace方法,当碰到挂载云盘的情况,如alist挂载阿里云盘,会导致结果直接溢出

## Brief changelog
检测到总容量为负值,直接赋值总容量为 Long.MAX_VALUE / 64 的值

或者在代码中检测各个盘符的值是否大于某个阈值,跳过本次循环

## Verifying this change
![image](https://github.com/PowerJob/PowerJob/assets/36041260/b4e8a613-dfba-4db9-b63a-9680d3e9042b)


Do I need to test? yes
Has testing been completed? yes
Test method? 
Download Alist and raiddrive to reproduce bugs
