### PR TITLE
fix: When both InputStream and ErrorStream exist, copyStream cannot guarantee sequential execution

### DIFF
--- a/powerjob-official-processors/src/main/java/tech/powerjob/official/processors/impl/script/AbstractScriptProcessor.java
+++ b/powerjob-official-processors/src/main/java/tech/powerjob/official/processors/impl/script/AbstractScriptProcessor.java
@@ -96,6 +96,9 @@ public abstract class AbstractScriptProcessor extends CommonBasicProcessor {
             omsLogger.info("[SYSTEM] ScriptProcessor has been interrupted");
         } finally {
             result = String.format("[INPUT]: %s;[ERROR]: %s", inputBuilder, errorBuilder);
+            // 同步到在线日志
+            omsLogger.info(inputBuilder.toString());
+            omsLogger.info(errorBuilder.toString());
         }
         return new ProcessResult(success, result);
     }
@@ -144,8 +147,6 @@ public abstract class AbstractScriptProcessor extends CommonBasicProcessor {
         try (BufferedReader br = new BufferedReader(new InputStreamReader(is, charset))) {
             while ((line = br.readLine()) != null) {
                 sb.append(line).append(System.lineSeparator());
-                // 同步到在线日志
-                omsLogger.info(line);
             }
         } catch (Exception e) {
             log.warn("[ScriptProcessor] copyStream failed.", e);


### PR DESCRIPTION
When both the input stream and the error stream exist in the script processor, the "copyStream" cannot guarantee sequential execution of these streams.

## What is the purpose of the change

To guarantee that the output of the task in the script processor is ordered.

## Brief changelog

To move the log submits to when the task completed.

## Verifying this change

For example, a python script as the following:

```
print("hello, world")
print(hello, world)
```

Both the input stream and the error stream exist in this python script,  we found that the execution result outputs of this python script were unordered when we view its logs. Therefore, we remove the omsLogger submits in the "copyStream" and move it to when the task completed.
