### PR TITLE
添加原生 python 支持，消除 python 命令找不到的问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,4 +51,4 @@ services:
     entrypoint:
       - "sh"
       - "-c"
-      - "chmod +x wait-for-it.sh && ./wait-for-it.sh powerjob-server:7700 --strict -- java -Xmx512m -jar /powerjob-worker-samples.jar --powerjob.worker.server-address=powerjob-server:7700"
+      - "link /usr/bin/python3 /usr/bin/python && chmod +x wait-for-it.sh && ./wait-for-it.sh powerjob-server:7700 --strict -- java -Xmx512m -jar /powerjob-worker-samples.jar --powerjob.worker.server-address=powerjob-server:7700"


### PR DESCRIPTION
# Python 处理器

- tech.powerjob.official.processors.impl.script.PythonProcessor 默认执行失败
- 添加 link ，使得python 容器能够 执行 类似于 print("hello world") 的能力