### PR TITLE
新增自动创建app和自动注册job逻辑

### DIFF
--- a/powerjob-worker-spring-boot-starter/pom.xml
+++ b/powerjob-worker-spring-boot-starter/pom.xml
@@ -47,6 +47,20 @@
             <scope>test</scope>
         </dependency>
 
+
+        <dependency>
+            <groupId>tech.powerjob</groupId>
+            <artifactId>powerjob-client</artifactId>
+            <version>${powerjob.worker.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.4</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
 </project>

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobProperties.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobProperties.java
@@ -1,14 +1,14 @@
 package tech.powerjob.worker.autoconfigure;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import tech.powerjob.common.RemoteConstant;
 import tech.powerjob.common.enums.Protocol;
 import tech.powerjob.worker.common.constants.StoreStrategy;
 import tech.powerjob.worker.core.processor.ProcessResult;
 import tech.powerjob.worker.core.processor.WorkflowContext;
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * PowerJob properties configuration class.
@@ -16,14 +16,12 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
  * @author songyinyin
  * @since 2020/7/26 16:37
  */
+@Getter
 @ConfigurationProperties(prefix = "powerjob")
 public class PowerJobProperties {
 
     private final Worker worker = new Worker();
-
-    public Worker getWorker() {
-        return worker;
-    }
+    private final Registry registry = new Registry();
 
     @Deprecated
     @DeprecatedConfigurationProperty(replacement = "powerjob.worker.app-name")
@@ -169,6 +167,24 @@ public class PowerJobProperties {
          * Interval(s) of worker health report
          */
         private Integer healthReportInterval = 10;
+
+    }
+
+
+    @Setter
+    @Getter
+    public static class Registry {
+
+        /**
+         * 开启自动注册job
+         */
+        private boolean enableAutoRegistry = true;
+
+        /**
+         * 自动注册
+         * app密码 默认1No2Bug3Thanks
+         */
+        private String appPassword = "1No2Bug3Thanks";
 
     }
 }

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/registry/AutoRegistryJobBean.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/registry/AutoRegistryJobBean.java
@@ -1,0 +1,102 @@
+package tech.powerjob.worker.autoconfigure.registry;
+
+import com.google.common.collect.Lists;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.util.ClassUtils;
+import tech.powerjob.client.IPowerJobClient;
+import tech.powerjob.common.request.http.SaveJobInfoRequest;
+import tech.powerjob.common.request.query.JobInfoQuery;
+import tech.powerjob.common.response.JobInfoDTO;
+import tech.powerjob.common.response.ResultDTO;
+import tech.powerjob.worker.autoconfigure.PowerJobProperties;
+import tech.powerjob.worker.core.processor.sdk.BasicProcessor;
+import tech.powerjob.worker.sdk.ProcessRegistry;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 要开启自动注册需要引入client的包,就会自动注册
+ *
+ * @author minsin/mintonzhang@163.com
+ * @since 2024/1/16
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class AutoRegistryJobBean implements InitializingBean {
+
+    /**
+     * 被注入spring的bean
+     */
+    private final ObjectProvider<List<BasicProcessor>> processorList;
+
+    private final PowerJobProperties powerJobProperties;
+    private final IPowerJobClient powerJobClient;
+
+
+    @Override
+    public void afterPropertiesSet() {
+        List<ProcessRegistry> collect = processorList.getIfAvailable(Collections::emptyList)
+                .stream()
+                .filter(ProcessRegistry.class::isInstance)
+                .map(ProcessRegistry.class::cast)
+                .collect(Collectors.toList());
+        if (collect.isEmpty()) {
+            return;
+        }
+
+        //检查app信息
+        PowerJobProperties.Worker worker = powerJobProperties.getWorker();
+        String appName = worker.getAppName();
+
+
+        for (ProcessRegistry registry : collect) {
+            Class<?> userClass = ClassUtils.getUserClass(registry);
+            String classFileName = userClass.getName();
+
+            String jobName;
+            if ("DEFAULT".equals(registry.name())) {
+                jobName = appName + '#' + userClass.getSimpleName();
+            } else {
+                jobName = registry.name();
+            }
+
+            //根据tag和process 搜索job是否存在
+            JobInfoQuery jobInfoQuery = new JobInfoQuery();
+            jobInfoQuery.setTagEq(worker.getAppName());
+            jobInfoQuery.setProcessorInfoEq(classFileName);
+            jobInfoQuery.setStatusIn(Lists.newArrayList(1));
+            ResultDTO<List<JobInfoDTO>> listResultDTO = powerJobClient.queryJob(jobInfoQuery);
+            List<JobInfoDTO> data = listResultDTO.getData();
+
+
+            if (data.isEmpty()) {
+                //注册
+                SaveJobInfoRequest saveJobInfoRequest = new SaveJobInfoRequest();
+                saveJobInfoRequest.setJobName(jobName);
+                saveJobInfoRequest.setJobDescription(registry.description());
+                saveJobInfoRequest.setTimeExpressionType(registry.timeExpression().getTimeExpressionType());
+                saveJobInfoRequest.setTimeExpression(registry.timeExpression().getTimeExpression());
+                saveJobInfoRequest.setExecuteType(registry.executeType());
+                saveJobInfoRequest.setProcessorType(registry.processorType());
+                saveJobInfoRequest.setProcessorInfo(classFileName);
+                saveJobInfoRequest.setEnable(registry.enable());
+                saveJobInfoRequest.setExtra("Client Auto Registry");
+                saveJobInfoRequest.setTag(appName);
+                saveJobInfoRequest.setLogConfig(registry.logConfig());
+                powerJobClient.saveJob(saveJobInfoRequest);
+                log.info("[PowerJobRegistry] 自动注册job成功,process({}),jobName:({})", classFileName, jobName);
+            } else {
+                log.warn("[PowerJobRegistry] 自动注册job失败,job已经存在, process({}),jobName:({})", classFileName, jobName);
+            }
+        }
+
+
+    }
+}
+
+

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/registry/PowerJobAutoRegistryConfiguration.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/registry/PowerJobAutoRegistryConfiguration.java
@@ -1,0 +1,75 @@
+package tech.powerjob.worker.autoconfigure.registry;
+
+import com.google.common.collect.Lists;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.powerjob.client.IPowerJobClient;
+import tech.powerjob.client.PowerJobClient;
+import tech.powerjob.worker.autoconfigure.PowerJobProperties;
+import tech.powerjob.worker.core.processor.sdk.BasicProcessor;
+import tech.powerjob.worker.sdk.RegistryAppUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 要开启自动注册需要引入client的包,就会自动注册
+ *
+ * @author minsin/mintonzhang@163.com
+ * @since 2024/1/16
+ */
+@ConditionalOnClass(IPowerJobClient.class)
+@ConditionalOnProperty(prefix = "powerjob.registry", name = "enable-auto-registry", havingValue = "true", matchIfMissing = true)
+@Configuration
+@AutoConfigureBefore(PowerJobAutoRegistryConfiguration.class)
+@RequiredArgsConstructor
+@Slf4j
+public class PowerJobAutoRegistryConfiguration implements InitializingBean {
+
+    private final PowerJobProperties powerJobProperties;
+
+    @Bean
+    @ConditionalOnMissingBean
+    public IPowerJobClient powerJobClient() {
+        PowerJobProperties.Worker worker = powerJobProperties.getWorker();
+        PowerJobProperties.Registry registry = powerJobProperties.getRegistry();
+        ArrayList<String> addresses = Lists.newArrayList(StringUtils.split(worker.getServerAddress(), ","));
+        return new PowerJobClient(addresses, worker.getAppName(), registry.getAppPassword());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AutoRegistryJobBean autoRegistryJob(ObjectProvider<List<BasicProcessor>> processorList, IPowerJobClient powerJobClient) {
+        return new AutoRegistryJobBean(processorList, powerJobProperties, powerJobClient);
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        PowerJobProperties.Worker worker = powerJobProperties.getWorker();
+        PowerJobProperties.Registry registry = powerJobProperties.getRegistry();
+        //尝试注册app
+        ArrayList<String> addresses = Lists.newArrayList(StringUtils.split(worker.getServerAddress(), ","));
+        AtomicBoolean flag = new AtomicBoolean(false);
+
+        RegistryAppUtils.tryRegisterApp(flag, worker.getAppName(), registry.getAppPassword(), addresses);
+
+        if (flag.get()) {
+            log.info("[PowerJobRegistry] 注册App成功,appName:({}),password:({}),serverAddress:({})", worker.getAppName(), registry.getAppPassword(), worker.getServerAddress());
+        } else {
+            log.warn("[PowerJobRegistry] 自动注册失败,请检查服务端是否存在,appName:({}),password:({}),serverAddress:({})", worker.getAppName(), registry.getAppPassword(), worker.getServerAddress());
+        }
+
+    }
+
+
+}

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/sdk/ProcessRegistry.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/sdk/ProcessRegistry.java
@@ -1,0 +1,65 @@
+package tech.powerjob.worker.sdk;
+
+import tech.powerjob.common.enums.ExecuteType;
+import tech.powerjob.common.enums.ProcessorType;
+import tech.powerjob.common.model.LogConfig;
+
+/**
+ * @author minsin/mintonzhang@163.com
+ * @since 2024/1/16
+ */
+
+public interface ProcessRegistry {
+
+
+    /**
+     * 任务名称
+     */
+    default String name() {
+        return "DEFAULT";
+    }
+
+    /**
+     * 任务描述
+     */
+    default String description() {
+        return "DEFAULT";
+    }
+
+
+    /**
+     * 执行方式
+     */
+    default ExecuteType executeType() {
+
+        return ExecuteType.STANDALONE;
+    }
+
+
+    /**
+     * 执行类型
+     */
+    default ProcessorType processorType() {
+        return ProcessorType.BUILT_IN;
+    }
+
+
+    TimeExpression timeExpression();
+
+
+    default LogConfig logConfig() {
+        //参考 log type {@link tech.powerjob.common.enums.LogType}
+        //参考 log type  {@link tech.powerjob.common.enums.LogLevel}
+        return new LogConfig()
+                .setLevel(2)
+                .setType(1);
+    }
+
+    /**
+     * 注册后自动执行
+     */
+    default boolean enable() {
+        return true;
+    }
+
+}

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/sdk/RegistryAppUtils.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/sdk/RegistryAppUtils.java
@@ -1,0 +1,46 @@
+package tech.powerjob.worker.sdk;
+
+import com.alibaba.fastjson.JSON;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import tech.powerjob.client.TypeStore;
+import tech.powerjob.common.OmsConstant;
+import tech.powerjob.common.response.ResultDTO;
+import tech.powerjob.common.utils.HttpUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author minsin/mintonzhang@163.com
+ * @since 2024/1/17
+ */
+public abstract class RegistryAppUtils {
+
+    public static void tryRegisterApp(AtomicBoolean flag, String appName, String password, List<String> addressList) {
+
+        HashMap<String, String> request = new HashMap<>();
+        request.put("appName", appName);
+        request.put("password", password);
+
+        RequestBody requestBody = RequestBody.create(MediaType.parse(OmsConstant.JSON_MEDIA_TYPE), JSON.toJSONString(request));
+
+
+        for (String address : addressList) {
+            try {
+                String url = String.format("http://%s%s%s", address, "", "/appInfo/save");
+                String post = HttpUtils.post(url, requestBody);
+                //JSON
+                ResultDTO<Void> result = JSON.parseObject(post, TypeStore.VOID_RESULT_TYPE);
+                if (result.isSuccess()) {
+                    flag.set(true);
+                    break;
+                }
+            } catch (Exception ignore) {
+
+            }
+        }
+
+    }
+}

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/sdk/TimeExpression.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/sdk/TimeExpression.java
@@ -1,0 +1,22 @@
+package tech.powerjob.worker.sdk;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import tech.powerjob.common.enums.TimeExpressionType;
+
+/**
+ * @author minsin/mintonzhang@163.com
+ * @since 2024/1/17
+ */
+@Getter
+@RequiredArgsConstructor
+public class TimeExpression {
+
+    private final TimeExpressionType timeExpressionType;
+
+    private final String timeExpression;
+
+    public static TimeExpression of(TimeExpressionType timeExpressionType, String timeExpression) {
+        return new TimeExpression(timeExpressionType, timeExpression);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

新增自动创建app和自动注册job逻辑

## Brief changelog

之前是用的quartz，现在切换到powerjob，每一个定时器都需要手动注册。实在太麻烦了！
所以在powerjob-worker-spring-boot-starter中新增了一些关于自动注册的配置类。（原本还改了client相关配置，本着最小修改原则，还原了）


## Verifying this change
目前有以下功能：
stater中包含client配置，但是是可选的，如果没有加入power-client则不会自动注册
1、自动创建app
2、自动根据ProcessRegistry的信息进行job注册

我已验证
                    