### PR TITLE
1.自定义id序列生成器解决数据库采用序列来生成主键的时候避免所有表共用一个序列，而是每个表拥有一个独立的序列来生成

### DIFF
--- a/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/config/id/enhanced/CustomIdentifierGeneratorStrategyProviderProvider.java
+++ b/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/config/id/enhanced/CustomIdentifierGeneratorStrategyProviderProvider.java
@@ -1,0 +1,23 @@
+package tech.powerjob.server.persistence.config.id.enhanced;
+
+import org.hibernate.jpa.spi.IdentifierGeneratorStrategyProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * description 新增或者覆盖之前的的id生成策略
+ * 使用方式 在 配置文件配置
+ * spring.datasource.remote.hibernate.properties.hibernate.identifier_generator_strategy_provider=tech.powerjob.server.persistence.config.id.enhanced.CustomIdentifierGeneratorStrategyProviderProvider
+ * @author jian chen jiang
+ * date 2024/3/1 22:08
+ */
+public class CustomIdentifierGeneratorStrategyProviderProvider implements IdentifierGeneratorStrategyProvider {
+    @Override
+    public Map<String, Class<?>> getStrategies() {
+        Map<String,Class<?>> strages = new HashMap<>();
+        //覆盖掉默认的
+        strages.put("sequence", CustomSequenceStyleGenerator.class);
+        return strages;
+    }
+}

--- a/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/config/id/enhanced/CustomSequenceStyleGenerator.java
+++ b/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/config/id/enhanced/CustomSequenceStyleGenerator.java
@@ -1,0 +1,26 @@
+package tech.powerjob.server.persistence.config.id.enhanced;
+
+import org.hibernate.boot.model.relational.QualifiedName;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
+import org.hibernate.service.ServiceRegistry;
+
+import java.util.Properties;
+
+/**
+ * description 重写利用序列生成id策略生成器
+ *
+ * @author jian chen jiang
+ * date 2024/3/1 22:18
+ */
+public class CustomSequenceStyleGenerator extends SequenceStyleGenerator {
+    @Override
+    protected QualifiedName determineSequenceName(Properties params, Dialect dialect, JdbcEnvironment jdbcEnv, ServiceRegistry serviceRegistry) {
+        if(!params.contains(CONFIG_PREFER_SEQUENCE_PER_ENTITY)){
+            //让每个表用自己的序列生成器 ，hibernate 6系列 这个是默认配置故可以不用配置了
+            params.setProperty(CONFIG_PREFER_SEQUENCE_PER_ENTITY,"true");
+        }
+        return super.determineSequenceName(params, dialect, jdbcEnv, serviceRegistry);
+    }
+}


### PR DESCRIPTION
1.自定义id序列生成器解决数据库采用序列来生成主键的时候避免所有表共用一个序列，而是每个表拥有一个独立的序列来生成