### PR TITLE
1.修复任务实例重跑完后读取的还是上一次的日志内容

### DIFF
--- a/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/instance/InstanceService.java
+++ b/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/instance/InstanceService.java
@@ -65,6 +65,8 @@ public class InstanceService {
 
     private final WorkerClusterQueryService workerClusterQueryService;
 
+    private final InstanceLogService instanceLogService;
+
     /**
      * 创建任务实例（注意，该方法并不调用 saveAndFlush，如果有需要立即同步到DB的需求，请在方法结束后手动调用 flush）
      * ********************************************
@@ -183,6 +185,13 @@ public class InstanceService {
         // 派发任务
         Long jobId = instanceInfo.getJobId();
         JobInfoDO jobInfo = jobInfoRepository.findById(jobId).orElseThrow(() -> new PowerJobException("can't find job info by jobId: " + jobId));
+        //删除掉之前的日志文件
+        try {
+            instanceLogService.removeOldFile(instanceId);
+        } catch (Exception e) {
+            //不能影响主流程 若删除失败
+            log.error("[InstanceLogService] delete old logs for instance: "+instanceId+" failed.",e);
+        }
         dispatchService.dispatch(jobInfo, instanceId,Optional.of(instanceInfo),Optional.empty());
     }
 


### PR DESCRIPTION
为啥会出现这个bug?
  1.实例重试的时候 不会重新生成一条 实例 只是修改状态，故之前的持久化 本地的日志文件还是存在的。
  分析关键获取日志的代码：
tech.powerjob.server.core.instance.InstanceLogService#genStableLogFile
![image](https://github.com/PowerJob/PowerJob/assets/66168320/f57d1adf-f2ea-4e54-9924-cc9aa7a37a8e)
 
  