### PR TITLE
Add GaussDB Driver to support GaussDB

### DIFF
--- a/powerjob-server/pom.xml
+++ b/powerjob-server/pom.xml
@@ -37,6 +37,7 @@
         <postgresql.version>42.6.0</postgresql.version>
         <h2.db.version>2.2.224</h2.db.version>
         <mongodb-driver-sync.version>4.10.2</mongodb-driver-sync.version>
+        <opengauss.version>5.1.0-og</opengauss.version>
 
         <zip4j.version>2.11.2</zip4j.version>
         <jgit.version>5.13.2.202306221912-r</jgit.version>
@@ -202,6 +203,12 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.db.version}</version>
+        </dependency>
+        <!-- opengauss -->
+        <dependency>
+            <groupId>org.opengauss</groupId>
+            <artifactId>opengauss-jdbc</artifactId>
+            <version>${opengauss.version}</version>
         </dependency>
 
         <!-- SpringBoot -->

--- a/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/config/dialect/AdpOpenGaussSQLDialect.java
+++ b/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/config/dialect/AdpOpenGaussSQLDialect.java
@@ -11,8 +11,7 @@ import java.sql.Types;
  * 拷贝自AdpPostgreSQLDialect，用来处理OpenGauss相关数据类型发言
  * 使用方自行通过配置文件激活：spring.datasource.remote.hibernate.properties.hibernate.dialect=tech.powerjob.server.persistence.config.dialect.AdpOpenGaussSQLDialect
  *
- * @author litong0531
- * @since 2024/8/11
+ * @since 2024/11/12
  */
 public class AdpOpenGaussSQLDialect extends PostgreSQL10Dialect {
 

--- a/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/config/dialect/AdpOpenGaussSQLDialect.java
+++ b/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/config/dialect/AdpOpenGaussSQLDialect.java
@@ -1,0 +1,37 @@
+package tech.powerjob.server.persistence.config.dialect;
+
+import org.hibernate.dialect.PostgreSQL10Dialect;
+import org.hibernate.type.descriptor.sql.LongVarbinaryTypeDescriptor;
+import org.hibernate.type.descriptor.sql.LongVarcharTypeDescriptor;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
+
+import java.sql.Types;
+
+/**
+ * 拷贝自AdpPostgreSQLDialect，用来处理OpenGauss相关数据类型发言
+ * 使用方自行通过配置文件激活：spring.datasource.remote.hibernate.properties.hibernate.dialect=tech.powerjob.server.persistence.config.dialect.AdpOpenGaussSQLDialect
+ *
+ * @author litong0531
+ * @since 2024/8/11
+ */
+public class AdpOpenGaussSQLDialect extends PostgreSQL10Dialect {
+
+    public AdpOpenGaussSQLDialect() {
+        super();
+        registerColumnType(Types.BLOB, "bytea");
+        registerColumnType(Types.CLOB, "text");
+    }
+
+    @Override
+    public SqlTypeDescriptor remapSqlTypeDescriptor(SqlTypeDescriptor sqlTypeDescriptor) {
+        switch (sqlTypeDescriptor.getSqlType()) {
+            case Types.CLOB:
+                return LongVarcharTypeDescriptor.INSTANCE;
+            case Types.BLOB:
+                return LongVarbinaryTypeDescriptor.INSTANCE;
+            case Types.NCLOB:
+                return LongVarbinaryTypeDescriptor.INSTANCE;
+        }
+        return super.remapSqlTypeDescriptor(sqlTypeDescriptor);
+    }
+}

--- a/powerjob-server/powerjob-server-starter/src/main/resources/application-daily.properties
+++ b/powerjob-server/powerjob-server-starter/src/main/resources/application-daily.properties
@@ -10,7 +10,7 @@ spring.datasource.core.maximum-pool-size=20
 spring.datasource.core.minimum-idle=5
 
 ####### Huawei GaussDB properties #######
-#spring.datasource.remote.hibernate.properties.hibernate.dialect=tech.powerjob.server.persistence.config.dialect.AdpPostgreSQLDialect
+#spring.datasource.remote.hibernate.properties.hibernate.dialect=tech.powerjob.server.persistence.config.dialect.AdpOpenGaussSQLDialect
 #spring.datasource.core.driver-class-name=org.opengauss.Driver
 #spring.datasource.core.jdbc-url=jdbc:opengauss://<IP>:<port>/powerjob_daily?currentSchema=public
 #spring.datasource.core.username=<username>

--- a/powerjob-server/powerjob-server-starter/src/main/resources/application-daily.properties
+++ b/powerjob-server/powerjob-server-starter/src/main/resources/application-daily.properties
@@ -9,6 +9,18 @@ spring.datasource.core.password=No1Bug2Please3!
 spring.datasource.core.maximum-pool-size=20
 spring.datasource.core.minimum-idle=5
 
+####### Huawei GaussDB properties #######
+#spring.datasource.remote.hibernate.properties.hibernate.dialect=tech.powerjob.server.persistence.config.dialect.AdpPostgreSQLDialect
+#spring.datasource.core.driver-class-name=org.opengauss.Driver
+#spring.datasource.core.jdbc-url=jdbc:opengauss://<IP>:<port>/powerjob_daily?currentSchema=public
+#spring.datasource.core.username=<username>
+#spring.datasource.core.password=<password>
+#spring.datasource.core.maximum-pool-size=20
+#spring.datasource.core.minimum-idle=5
+#spring.jpa.database=postgresql
+#spring.jpa.hibernate.ddl-auto=update
+
+
 ####### Storage properties(Delete if not needed)  #######
 #oms.storage.dfs.mongodb.uri=mongodb+srv://zqq:No1Bug2Please3!@cluster0.wie54.gcp.mongodb.net/powerjob_daily?retryWrites=true&w=majority
 oms.storage.dfs.mysql_series.driver=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
Add Huawei GaussDB Driver to support GaussDB,and provider an  example with config properties.
Creating a database SQL : " CREATE DATABASE powerjob_daily".
U can use the Navicat Premium 17 to connect The GaussDB.

