### PR TITLE
fix: openapi添加工作流节点方法 无法反序列化nodeName属性

### DIFF
--- a/powerjob-common/src/main/java/tech/powerjob/common/response/WorkflowNodeInfoDTO.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/response/WorkflowNodeInfoDTO.java
@@ -6,6 +6,7 @@ import java.util.Date;
 
 /**
  * WorkflowNodeInfo 对外输出对象
+ *
  * @author Echo009
  * @since 2021/2/20
  */
@@ -24,7 +25,7 @@ public class WorkflowNodeInfoDTO {
     /**
      * 节点别名，默认为对应的任务名称
      */
-    private String nodeAlias;
+    private String nodeName;
     /**
      * 节点参数
      */


### PR DESCRIPTION
## What is the purpose of the change

OpenAPI 添加工作流节点接口的返回对象WorkflowNodeInfoDTO中nodeAlias属性无法与WorkflowNodeInfoDO中的nodeName属性对应,导致返回空值 https://github.com/PowerJob/PowerJob/issues/1046