### PR TITLE
修复client auth header 鉴权机制，经过Nginx代理之后不生效的问题

### DIFF
--- a/powerjob-client/src/main/java/tech/powerjob/client/service/impl/AppAuthClusterRequestService.java
+++ b/powerjob-client/src/main/java/tech/powerjob/client/service/impl/AppAuthClusterRequestService.java
@@ -46,6 +46,11 @@ abstract class AppAuthClusterRequestService extends ClusterRequestService {
 
         // 如果 auth 成功，则代表请求有效，直接返回
         String authStatus = MapUtils.getString(httpResponse.getHeaders(), OpenAPIConstant.RESPONSE_HEADER_AUTH_STATUS);
+        // 继续尝试获取转为小写之后的 auth header (Nginx代理默认会将自定义header转为纯小写, 实现针对该情况的兼容)
+        if (StringUtils.isEmpty(authStatus)) {
+            authStatus = MapUtils.getString(httpResponse.getHeaders(),
+                    OpenAPIConstant.RESPONSE_HEADER_AUTH_STATUS.toLowerCase());
+        }
         if (Boolean.TRUE.toString().equalsIgnoreCase(authStatus)) {
             return httpResponse.getResponse();
         }


### PR DESCRIPTION
Nginx代理默认会将自定义header转为纯小写，auth 通过后 powerjob server 返回的header为X-POWERJOB-AUTH-PASSED，经过Nginx代理之后header会自动变为 x-powerjob-auth-passed，从而导致 client 端 auth 校验失败，这种情况下会导致请求重复发送两次的问题，该修复方案实现针对此类情况的兼容。

![局部截取_20250413_230227](https://github.com/user-attachments/assets/542ed69e-9919-496b-9489-dda76e84bed3)
              