### PR TITLE
feat: #1119 Make FrequentTaskTracker Dispatch Interval Configurable

### DIFF
--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobAutoConfiguration.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobAutoConfiguration.java
@@ -85,6 +85,8 @@ public class PowerJobAutoConfiguration {
         config.setMaxLightweightTaskNum(worker.getMaxLightweightTaskNum());
 
         config.setHealthReportInterval(worker.getHealthReportInterval());
+
+        config.setFrequentTaskDispatchInterval(worker.getFrequentTaskDispatchInterval());
         /*
          * Create PowerJobSpringWorker object and set properties.
          */

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobProperties.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobProperties.java
@@ -169,6 +169,10 @@ public class PowerJobProperties {
          * Interval(s) of worker health report
          */
         private Integer healthReportInterval = 10;
+        /**
+         * Interval(ms) of worker subtask dispatch
+         */
+        private Long frequentTaskDispatchInterval = 2000L;
 
     }
 }

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/common/PowerJobWorkerConfig.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/common/PowerJobWorkerConfig.java
@@ -88,5 +88,9 @@ public class PowerJobWorkerConfig {
      * Interval(s) of worker health report
      */
     private Integer healthReportInterval = 10;
+    /**
+     * Interval(ms) of worker frequent task dispatch
+     */
+    private Long frequentTaskDispatchInterval = 2000L;
 
 }

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/core/tracker/task/heavy/FrequentTaskTracker.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/core/tracker/task/heavy/FrequentTaskTracker.java
@@ -117,7 +117,7 @@ public class FrequentTaskTracker extends HeavyTaskTracker {
         }
 
         // 3. 启动任务分发器（事实上，秒级任务应该都是单机任务，且感觉不需要失败重试机制，那么 Dispatcher 的存在就有点浪费系统资源了...）
-        scheduledPool.scheduleWithFixedDelay(new Dispatcher(), 1, 2, TimeUnit.SECONDS);
+        scheduledPool.scheduleWithFixedDelay(new Dispatcher(), 1000, workerRuntime.getWorkerConfig().getFrequentTaskDispatchInterval(), TimeUnit.MILLISECONDS);
         // 4. 启动状态检查器
         scheduledPool.scheduleWithFixedDelay(new Checker(), 5000, Math.min(Math.max(timeParams, 5000), 15000), TimeUnit.MILLISECONDS);
         // 5. 启动执行器动态检测装置


### PR DESCRIPTION
## What is the purpose of the change

Make the **FrequentTaskTracker** dispatch interval configurable (instead of being hardcoded to 2 seconds).
This change makes PowerJob Worker more flexible and adaptable for different workloads (e.g., low-latency real-time tasks vs. batch tasks).

## Brief changelog

Added a configurable property `powerjob.frequent-task.dispatch-interval`to control the dispatch interval of `FrequentTaskTracker`.

Default value remains `2000` ms (2 seconds) to ensure backward compatibility.

Updated `FrequentTaskTracker` scheduling logic to read the value from configuration (or system property).

Associated Issue: [#1119](https://github.com/PowerJob/PowerJob/issues/1119)

## Verifying this change

- Manually verified by starting a Worker with custom property:
`powerjob.frequent-task.dispatch-interval=1000`
Confirmed that sub-tasks are dispatched every 1000 ms instead of 2 seconds.
- Unit test added for property loading and fallback to default value.
- No regression observed when running with default value.
   
                    