### PR TITLE
feat: worker change to use spring boot 3 and add helm chart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <lombok.version>1.18.38</lombok.version>
+        <lombok.version>1.18.42</lombok.version>
     </properties>
 
     <dependencies>
@@ -87,6 +87,13 @@
                             <target>${java.version}</target>
                             <testSource>${java.version}</testSource>
                             <testTarget>${java.version}</testTarget>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok</artifactId>
+                                    <version>${lombok.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
                         </configuration>
                     </plugin>
                     <!-- Package source codes -->
@@ -184,6 +191,13 @@
                             <target>${java.version}</target>
                             <testSource>${java.version}</testSource>
                             <testTarget>${java.version}</testTarget>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok</artifactId>
+                                    <version>${lombok.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
                         </configuration>
                     </plugin>
                     <!-- Edit MANIFEST.MF -->

--- a/powerjob-official-processors/pom.xml
+++ b/powerjob-official-processors/pom.xml
@@ -15,23 +15,20 @@
     <packaging>jar</packaging>
 
     <properties>
+        <java.version>25</java.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
 
         <mvn.shade.plugin.version>3.2.4</mvn.shade.plugin.version>
 
         <!-- 不会被打包的部分，scope 只能是 test 或 provide -->
-        <junit.version>5.9.1</junit.version>
-        <logback.version>1.2.13</logback.version>
         <powerjob.worker.version>5.1.2</powerjob.worker.version>
-        <h2.db.version>2.2.224</h2.db.version>
-        <mysql.version>8.0.28</mysql.version>
-        <spring.version>5.3.31</spring.version>
+
 
         <!-- 全部 shade 化，避免依赖冲突 -->
         <fastjson.version>1.2.83</fastjson.version>
-        <okhttp.version>3.14.9</okhttp.version>
-        <guava.version>30.1.1-jre</guava.version>
-        <commons.io.version>2.11.0</commons.io.version>
-        <commons.lang.version>3.10</commons.lang.version>
+        <okhttp.version>5.2.1</okhttp.version>
+        <commons.io.version>2.20.0</commons.io.version>
     </properties>
 
     <dependencies>
@@ -50,6 +47,13 @@
             <version>${okhttp.version}</version>
         </dependency>
 
+        <!-- OKHttp -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-urlconnection</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+
         <!-- commons-io -->
         <dependency>
             <groupId>commons-io</groupId>
@@ -59,14 +63,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons.lang.version}</version>
         </dependency>
 
         <!-- guava -->
         <dependency>
-            <groupId>com.google.guava</groupId>
+            <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
 
         <dependency>
@@ -80,14 +82,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -95,7 +95,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -103,7 +102,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -111,14 +109,12 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>${h2.db.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>${mysql.version}</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -171,5 +167,15 @@
             </plugin>
         </plugins>
     </build>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>3.5.7</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/powerjob-server/docker/run-server.sh
+++ b/powerjob-server/docker/run-server.sh
@@ -1,0 +1,20 @@
+docker run -p 7700:7700 -p 10010:10010 -it --rm \
+    -e PARAMS="--spring.profiles.active=daily \
+    --spring.datasource.core.driver-class-name=org.h2.Driver \
+    --spring.datasource.core.jdbc-url=jdbc:h2:file:/tmp/powerjob/h2db;AUTO_SERVER=TRUE \
+    --spring.datasource.core.username=powerjob \
+    --spring.datasource.core.password=powerjob \
+    --oms.storage.dfs.mysql_series.driver=org.h2.Driver \
+    --oms.storage.dfs.mysql_series.url=jdbc:h2:file:/tmp/powerjob/h2db;AUTO_SERVER=TRUE \
+    --oms.storage.dfs.mysql_series.username=powerjob \
+    --oms.storage.dfs.mysql_series.password=powerjob \
+    --oms.storage.dfs.mysql_series.auto_create_table=true
+    --oms.instanceinfo.retention=30 \
+    --oms.container.retention.local=30 \
+    --oms.container.retention.remote=-1 \
+    --spring.mail.host=smtp-relay.gmail.com \
+    --spring.mail.username=test@gmail.com \
+    --spring.mail.password=test123 \
+    --oms.auth.initiliaze.admin.password=admin" \
+    -e JVMOPTIONS=" -Dpowerjob.network.external.address=127.0.0.1 -Xms512m -Xmx1024m -Xmn256m -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=256m" \
+    powerjob/powerjob-server:v5.1.2

--- a/powerjob-server/helm-chart/.helmignore
+++ b/powerjob-server/helm-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/powerjob-server/helm-chart/Chart.yaml
+++ b/powerjob-server/helm-chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: powerjob-pgsql
+description: PowerJob PGSQL Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 5.1.2
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v5.1.2"

--- a/powerjob-server/helm-chart/images/Dockerfile
+++ b/powerjob-server/helm-chart/images/Dockerfile
@@ -1,0 +1,44 @@
+#ARG powershell_version=7.5.4
+#ARG ARCH=${TARGETARCH/arm64/aarch64}
+#ARG ARCH=${ARCH/amd64/x86_64}
+#FROM powershell AS builder
+#ARG powershell_version
+#ARG TARGETARCH
+
+FROM powerjob/powerjob-agent:v5.1.2 AS powerjob-build
+
+
+FROM azul/zulu-openjdk-debian:17 AS powerjob-agent
+#ARG powershell_version
+ARG TARGETARCH
+
+ENV APP_NAME=powerjob-worker-agent
+ENV PARAMS=""
+ENV JVMOPTIONS=""
+
+RUN apt-get update && \
+    apt-get install -y python-is-python3 curl iproute2 iputils-ping \
+    && apt-get clean \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -o wait-for-it.sh https://gitee.com/KFCFans/wait-for-it/raw/master/wait-for-it.sh && \
+    curl -o powerjob-agent.jar https://github.com/PowerJob/PowerJob/ && \
+    curl -Lo dotnet-install.sh https://dot.net/v1/dotnet-install.sh
+RUN chmod +x wait-for-it.sh && \
+    chmod +x dotnet-install.sh && \
+    ./dotnet-install.sh --version latest --runtime dotnet
+
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+ENV DOTNET_ROOT=/root/.dotnet
+
+#COPY --from=builder /powershell_${powershell_version}-2_${TARGETARCH}.deb powershell_${powershell_version}-2_${TARGETARCH}.deb
+COPY --from=powerjob-build /powerjob-agent.jar powerjob-agent.jar
+
+#RUN dpkg -i  powershell_${powershell_version}-2_${TARGETARCH}.deb
+
+EXPOSE 27777
+
+VOLUME /root
+
+ENTRYPOINT ["sh","-c","java $JVMOPTIONS -jar /powerjob-agent.jar $PARAMS"]

--- a/powerjob-server/helm-chart/templates/NOTES.txt
+++ b/powerjob-server/helm-chart/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ .Release.Name }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ .Release.Name }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Release.Name }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ .Release.Name }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/powerjob-server/helm-chart/templates/agent-deployment.yaml
+++ b/powerjob-server/helm-chart/templates/agent-deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name | lower }}-agent
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.agent.replicaCount }}
+  selector:
+    matchLabels:
+      {{- .Values.agent.podLabels | toYaml | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- .Values.agent.podLabels | toYaml | nindent 8 }}
+    spec:
+      initContainers:
+        - name: wait-for-server
+          image: busybox:latest
+          envFrom:
+            - configMapRef:
+                name: {{ .Chart.Name | lower }}-common-config
+                optional: false
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until nc -z $(POWERJOB_SERVER_ADDRESS) $(POWERJOB_SERVER_PORT); do
+                echo "等待 PowerJob Server..."
+                sleep 5
+              done
+      containers:
+        - name: {{ .Release.Name }}-agent
+          image: {{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          ports:
+            {{- toYaml .Values.agent.ports | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Chart.Name | lower }}-common-config
+                optional: false
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: JVMOPTIONS
+              value: {{ .Values.agent.jvmOptions | quote }}
+            - name: PARAMS
+              value: {{ .Values.agent.params | quote }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.agent.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.agent.livenessProbe.path }}
+              port: {{ .Values.agent.livenessProbe.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.agent.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.agent.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.agent.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.agent.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.agent.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.agent.readinessProbe.path }}
+              port: {{ .Values.agent.readinessProbe.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.agent.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.agent.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.agent.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.agent.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: {{ .Values.startupProbe.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}

--- a/powerjob-server/helm-chart/templates/common-config.yaml
+++ b/powerjob-server/helm-chart/templates/common-config.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name | lower }}-common-config
+  namespace: {{ .Release.Namespace }}
+data:
+  PG_SERVICE_HOST: postgres.powerjob.svc.cluster.local
+  PG_SERVICE_PASSWORD: powerjob
+  PG_SERVICE_PORT: '5432'
+  PG_SERVICE_USER: powerjob
+  PG_SERVICE_DB: powerjob
+  PG_SERVICE_SCHEMA: powerjob
+  TIME_ZONE: Asia/Taipei
+  PG_DIALECT: "tech.powerjob.server.persistence.config.dialect.AdpPostgreSQLDialect"
+  MINIO_ENDPOINT: 	minio.powerjob.svc.cluster.local:9000
+  MAIL_USERNAME: services@test
+  MAIL_PASSWORD: test1234
+  POWERJOB_SERVER_PORT: '80'
+  POWERJOB_AGENT_EXTERNAL_PORT: '27777'
+  POWERJOB_SERVER_ADDRESS: {{ .Chart.Name | lower }}.{{ .Release.Namespace }}.svc.cluster.local
+  POWERJOB_SERVER_EXTERNAL_ADDRESS: {{ .Chart.Name | lower }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/powerjob-server/helm-chart/templates/deployment.yaml
+++ b/powerjob-server/helm-chart/templates/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name | lower }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- .Values.podLabels | toYaml | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- .Values.podLabels | toYaml | nindent 8 }}
+      namespace: {{ .Release.Namespace }}
+    spec:
+      initContainers:
+        - name: init-postgres
+          image: postgres:18
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+          envFrom:
+            - configMapRef:
+                name: {{ .Chart.Name | lower }}-common-config
+                optional: false
+          command:
+            - /bin/sh
+            - -c
+            - |
+                until pg_isready -h ${PG_SERVICE_HOST} -p 5432 -U ${PG_SERVICE_USER}; do
+                  echo "等待 PostgreSQL 就緒..."
+                  sleep 10
+                done
+                echo "PostgreSQL 已就緒，開始建立 sequence..."
+                PGPASSWORD=${PG_SERVICE_PASSWORD} psql -h ${PG_SERVICE_HOST} -U ${PG_SERVICE_USER} -d ${PG_SERVICE_DB} -c "CREATE SEQUENCE IF NOT EXISTS ${PG_SERVICE_SCHEMA}.native START WITH 1 INCREMENT BY 1;"
+                echo "Sequence 建立完成"
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: {{ .Chart.Name | lower }}-common-config
+                optional: false
+          env:
+            - name: SPRING_CONFIG_LOCATION
+              value: "classpath:/,/config/application.yml"
+            - name: JAVA_OPTS
+              value: "-Xmx2048m -Xms512m -XX:MaxMetaspaceSize=256m"
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: {{ .Release.Name }}
+          ports:
+            {{- toYaml .Values.containers.ports | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /config/application.yml
+              name: config-volume
+              subPath: application.yml
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: {{ .Values.startupProbe.port }}
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ .Chart.Name | lower }}-server-config
+      restartPolicy: Always
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}

--- a/powerjob-server/helm-chart/templates/ingressroute.yaml
+++ b/powerjob-server/helm-chart/templates/ingressroute.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ .Chart.Name | lower }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: PathPrefix(`/powerjob`)
+      services:
+        - name: {{ .Chart.Name | lower }}
+          {{- with index .Values.service.ports 0}}
+          port: {{ .name }}
+          {{- end}}

--- a/powerjob-server/helm-chart/templates/powerjob-config.yaml
+++ b/powerjob-server/helm-chart/templates/powerjob-config.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name | lower }}-server-config
+  namespace: {{ .Release.Namespace }}
+data:
+  application.yml: |
+    spring:
+      profiles:
+        active: daily
+      mail:
+        host: smtp-relay.gmail.ocm
+        port: 587
+        username: ${MAIL_USERNAME}
+        password: ${MAIL_PASSWORD}
+      datasource:
+        core:
+          driver-class-name: org.postgresql.Driver
+          jdbc-url: jdbc:postgresql://${PG_SERVICE_HOST}/${PG_SERVICE_DB}?currentSchema=${PG_SERVICE_SCHEMA},public,pg_catalog
+          username: ${PG_SERVICE_USER}
+          password: ${PG_SERVICE_PASSWORD}
+        remote:
+          hibernate:
+            properties:
+              hibernate:
+                ddl-auto: update
+                format_sql: true
+                dialect: ${PG_DIALECT}
+    logging:
+      level:
+        org.hibernate.SQL: DEBUG
+        org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+        tech.powerjob.server.core.lock.DatabaseLockService: INFO
+        org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator: INFO
+    oms:
+      transporter:
+        active:
+          protocols: http,mu
+        main:
+          protocol: http
+      container:
+        retention:
+          local: 7
+          remote: 14
+      instanceinfo:
+        retention: 7
+      instance:
+        meatadata:
+          cache:
+            size: 512
+      storage:
+        dfs:
+          mongodb: ${MINIO_ENDPOINT}
+          bucketName: powerjob-storage
+          accessKey: minio
+          secretKey: minio123

--- a/powerjob-server/helm-chart/templates/service.yaml
+++ b/powerjob-server/helm-chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name | lower }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name | lower }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ports }}
+  ports:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    {{- .Values.podLabels | toYaml | nindent 4 }}

--- a/powerjob-server/helm-chart/values.yaml
+++ b/powerjob-server/helm-chart/values.yaml
@@ -1,0 +1,180 @@
+# Default values for PMS.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+agent:
+  enable: true
+  replicaCount: 2
+  image:
+    repository: powerjob/powerjob-agent:latest
+    pullPolicy: IfNotPresent
+    tag: latest
+  ports: [
+    {
+      containerPort: 27777,
+      name: 27777tcp,
+      protocol: TCP
+    }
+  ]
+  podLabels: {
+    app: powerjob-agent-pgsql
+  }
+  #JVM 選項
+  jvmOptions: >-
+    -Dpowerjob.network.external.address=$(POD_IP)
+    -Dpowerjob.network.external.port=$(POWERJOB_AGENT_EXTERNAL_PORT)
+    -server
+    -XX:+UseG1GC
+    -XX:+PrintGCDetails
+    -Xlog:gc*:file=/root/gc-%t.log:time,level:filecount=7,filesize=100M
+  params: >-
+    --app testapp
+    --server $(POWERJOB_SERVER_ADDRESS):$(POWERJOB_SERVER_PORT)
+    --protocol=http
+    --tag=powerjob-agent
+  # 存活探針
+  livenessProbe:
+    enabled: true
+    path: /actuator/health
+    port: $(POWERJOB_AGENT_EXTERNAL_PORT)
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  # 就緒探針
+  readinessProbe:
+    enabled: true
+    path: /actuator/health
+    port: $(POWERJOB_AGENT_EXTERNAL_PORT)
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: powerjob/powerjob-server
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: v5.1.2
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: [
+  { name: "docker-registry" }
+]
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {
+  app: powerjob-server-pgsql
+}
+
+
+containers:
+  ports: [
+    {
+      containerPort: 7700,
+      name: 7700tcp,
+      protocol: TCP
+    },
+    {
+      containerPort: 10077,
+      name: 10077tcp,
+      protocol: TCP
+    },
+    {
+      containerPort: 10010,
+      name: 10010tcp,
+      protocol: TCP
+    }
+  ]
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  ports: [
+    {
+      name: powerjob-svc-80-port,
+      port: 80,
+      protocol: TCP,
+      targetPort: 7700tcp
+    },
+    {
+      name: powerjob-svc-10086-port,
+      port: 10086,
+      protocol: TCP,
+      targetPort: 10086tcp
+    },
+    {
+      name: powerjob-svc-10077-port,
+      port: 10077,
+      protocol: TCP,
+      targetPort: 10077tcp
+    }
+  ]
+
+resources: {
+  limits: {
+    cpu: '1',
+    memory: '1.5Gi'
+  },
+  requests: {
+    cpu: '0.5',
+    memory: '1Gi'
+  }
+}
+
+nodeSelector:
+  node: worker
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: NotIn
+              values:
+                - k3s1
+                - k3s2
+                - k3s3
+
+# 存活探針
+livenessProbe:
+  enabled: true
+  path: /actuator/health/liveness
+  port: 7700
+  initialDelaySeconds: 120
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# 就緒探針
+readinessProbe:
+  enabled: true
+  path: /actuator/health/readiness
+  port: 7700
+  initialDelaySeconds: 30
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# 啟動探針
+startupProbe:
+  enabled: true
+  path: /actuator/health
+  port: 7700
+  initialDelaySeconds: 60
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 30

--- a/powerjob-worker-agent/pom.xml
+++ b/powerjob-worker-agent/pom.xml
@@ -16,21 +16,14 @@
 
 
     <properties>
+        <java.version>25</java.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <powerjob.worker.version>5.1.2</powerjob.worker.version>
-        <logback.version>1.2.13</logback.version>
         <picocli.version>4.3.2</picocli.version>
-        <spring.version>5.3.31</spring.version>
 
-        <spring.boot.version>2.3.4.RELEASE</spring.boot.version>
 
         <powerjob.official.processors.version>5.1.2</powerjob.official.processors.version>
-
-        <!-- dependency for dynamic sql processor -->
-        <mysql.version>8.0.28</mysql.version>
-        <ojdbc.version>19.7.0.0</ojdbc.version>
-        <mssql-jdbc.version>7.4.1.jre8</mssql-jdbc.version>
-        <db2-jdbc.version>11.5.0.0</db2-jdbc.version>
-        <postgresql.version>42.2.14</postgresql.version>
     </properties>
 
     <dependencies>
@@ -57,55 +50,46 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
         </dependency>
 
         <!-- mysql -->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>${mysql.version}</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <!-- oracle -->
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
-            <version>${ojdbc.version}</version>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.nls</groupId>
             <artifactId>orai18n</artifactId>
-            <version>${ojdbc.version}</version>
         </dependency>
         <!-- sqlserver -->
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>${mssql-jdbc.version}</version>
         </dependency>
         <!-- db2 -->
         <dependency>
             <groupId>com.ibm.db2</groupId>
             <artifactId>jcc</artifactId>
-            <version>${db2-jdbc.version}</version>
         </dependency>
         <!-- postgresql -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version>
         </dependency>
 
         <!-- worker 移除了 Spring 强依赖，agent 需要使用容器功能必须直接依赖 -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
         </dependency>
     </dependencies>
 
@@ -116,7 +100,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <configuration>
                     <mainClass>tech.powerjob.agent.MainApplication</mainClass>
                 </configuration>
@@ -130,5 +113,15 @@
             </plugin>
         </plugins>
     </build>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>3.5.7</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/powerjob-worker-samples/pom.xml
+++ b/powerjob-worker-samples/pom.xml
@@ -14,9 +14,12 @@
     <version>5.1.2</version>
 
     <properties>
-        <springboot.version>2.7.18</springboot.version>
+        <springboot.version>3.5.7</springboot.version>
+        <java.version>25</java.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <powerjob.worker.starter.version>5.1.2</powerjob.worker.starter.version>
-        <fastjson.version>1.2.83</fastjson.version>
+        <fastjson.version>2.0.43</fastjson.version>
         <powerjob.official.processors.version>5.1.2</powerjob.official.processors.version>
 
         <!-- 部署时跳过该module -->
@@ -30,17 +33,14 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${springboot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>${springboot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${springboot.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -67,12 +67,16 @@
             <version>${powerjob-client.version}</version>
         </dependency>
 
-        <!-- 高版本 JDK 移除了 JavaEE 的包，需要手动引入 -->
+        <!-- 高版本 JDK 移除了 JavaEE 的包，需要手动引入 Jakarta EE -->
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
+
 
 
     </dependencies>
@@ -104,5 +108,15 @@
             </plugin>
         </plugins>
     </build>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>3.5.7</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/powerjob-worker-samples/src/main/java/tech/powerjob/samples/processors/MapProcessorDemo.java
+++ b/powerjob-worker-samples/src/main/java/tech/powerjob/samples/processors/MapProcessorDemo.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 

--- a/powerjob-worker-samples/src/main/resources/application.properties
+++ b/powerjob-worker-samples/src/main/resources/application.properties
@@ -19,3 +19,4 @@ powerjob.worker.store-strategy=disk
 powerjob.worker.max-result-length=4096
 # Max length of appended workflow context . Appended workflow context value that is longer than the value will be ignore.
 powerjob.worker.max-appended-wf-context-length=4096
+powerjob.network.external.address=127.0.0.1

--- a/powerjob-worker-spring-boot-starter/pom.xml
+++ b/powerjob-worker-spring-boot-starter/pom.xml
@@ -16,7 +16,10 @@
 
     <properties>
         <powerjob.worker.version>5.1.2</powerjob.worker.version>
-        <springboot.version>2.7.18</springboot.version>
+        <springboot.version>3.5.7</springboot.version>
+        <java.version>25</java.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/powerjob-worker-spring-boot-starter/src/test/resources/application.properties
+++ b/powerjob-worker-spring-boot-starter/src/test/resources/application.properties
@@ -1,1 +1,1 @@
-powerjob.enable-test-mode=true
+powerjob.worker.allow-lazy-connect-server=true

--- a/powerjob-worker/pom.xml
+++ b/powerjob-worker/pom.xml
@@ -15,13 +15,14 @@
     <packaging>jar</packaging>
 
     <properties>
-        <spring.version>5.3.31</spring.version>
-        <h2.db.version>2.2.224</h2.db.version>
-        <hikaricp.version>4.0.3</hikaricp.version>
-        <junit.version>5.9.1</junit.version>
+        <!-- Java 版本 -->
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
 
-        <logback.version>1.2.13</logback.version>
-
+        <!-- Hibernate 7 -->
+        <hibernate.version>7.0.0.Final</hibernate.version>
+        <okhttp.version>5.2.1</okhttp.version>
+        <!-- PowerJob 模块版本 -->
         <powerjob-common.version>5.1.2</powerjob-common.version>
         <powerjob-remote-framework.version>5.1.2</powerjob-remote-framework.version>
         <powerjob-remote-impl-akka.version>5.1.2</powerjob-remote-impl-akka.version>
@@ -30,77 +31,119 @@
     </properties>
 
     <dependencies>
-
-        <!-- 仍然手动引入 common 依赖并置顶，保证依赖仲裁时占据上风 -->
+        <!-- PowerJob 依赖保持不变 -->
         <dependency>
             <groupId>tech.powerjob</groupId>
             <artifactId>powerjob-common</artifactId>
             <version>${powerjob-common.version}</version>
         </dependency>
 
-        <!-- PowerJob 通讯框架 -->
+        <!-- OKHttp -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+
+        <!-- OKHttp -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-urlconnection</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>tech.powerjob</groupId>
             <artifactId>powerjob-remote-framework</artifactId>
             <version>${powerjob-remote-framework.version}</version>
         </dependency>
 
-        <!-- PowerJob 通讯层具体实现，按需选择自己需要的通讯器即可。如果包冲突可尝试更换通讯器实现，并排除未使用的通讯器包 -->
-        <!-- 4.3.x 版本前 AKKA 都是 PowerJob 通讯层的唯一实现，考虑到兼容性 4.3.x 默认仍为 AKKA，但由于 AKKA 后续收费，最终会废弃该模块，扶正太子（HTTP）上位 -->
         <dependency>
             <groupId>tech.powerjob</groupId>
             <artifactId>powerjob-remote-impl-akka</artifactId>
             <version>${powerjob-remote-impl-akka.version}</version>
         </dependency>
+
         <dependency>
             <groupId>tech.powerjob</groupId>
             <artifactId>powerjob-remote-impl-http</artifactId>
             <version>${powerjob-remote-impl-http.version}</version>
         </dependency>
+
         <dependency>
             <groupId>tech.powerjob</groupId>
             <artifactId>powerjob-remote-impl-mu</artifactId>
             <version>${powerjob-remote-impl-mu.version}</version>
         </dependency>
 
-        <!-- h2 database -->
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2.db.version}</version>
-        </dependency>
-        <!-- HikariCP, Java8 只能用 4.X 版本 -->
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <version>${hikaricp.version}</version>
-        </dependency>
-
-        <!-- Spring 依赖（非强依赖） -->
+        <!-- Spring Framework 6.2 核心依赖 -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
 
-        <!-- Junit 测试 -->
+        <!-- Hibernate 7 -->
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>${hibernate.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Jakarta EE API -->
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- 数据库依赖 -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+        </dependency>
+
+        <!-- 测试依赖 -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
-        <!-- log for test stage -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
-
-
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>3.5.7</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>


### PR DESCRIPTION
## What is the purpose of the change

 ISMS / PIMS Compliance , 因公司若需要使用 worker 开发系统时必需是没有 EOL的 Java 版本

更新了 worker 相关  pom.xml 中的多个依赖版本，包括 lombok、okhttp 和 commons-io，并替换了部分依赖（例如，将 MySQL 连接器切换为 mysql-connector-j）。此外，还为 Lombok 添加了显式的注解处理器路径，以提高构建的可靠性。

Helm Chart 与 Kubernetes 部署支持
                    