### PR TITLE
添加：添加新的克隆接口，用于多appname情况下 快速新增

### DIFF
--- a/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/service/impl/job/JobServiceImpl.java
+++ b/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/service/impl/job/JobServiceImpl.java
@@ -151,7 +151,6 @@ public class JobServiceImpl implements JobService {
 
         copyJob = jobInfoRepository.saveAndFlush(copyJob);
         return copyJob;
-
     }
 
     @Override

--- a/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/remote/repository/JobInfoRepository.java
+++ b/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/remote/repository/JobInfoRepository.java
@@ -32,6 +32,7 @@ public interface JobInfoRepository extends JpaRepository<JobInfoDO, Long>, JpaSp
 
     Page<JobInfoDO> findByAppIdAndJobNameLikeAndStatusNot(Long appId, String condition, int status, Pageable pageable);
 
+
     /**
      * 校验工作流包含的任务
      * @param appId APP ID

--- a/powerjob-server/powerjob-server-starter/src/main/java/tech/powerjob/server/web/AppWebService.java
+++ b/powerjob-server/powerjob-server-starter/src/main/java/tech/powerjob/server/web/AppWebService.java
@@ -17,6 +17,8 @@ public interface AppWebService {
 
     AppInfoDO save(ModifyAppInfoRequest request);
 
+    AppInfoDO clone(ModifyAppInfoRequest req);
+
     void delete(Long id);
 
     Optional<AppInfoDO> findByAppName(String appName);

--- a/powerjob-server/powerjob-server-starter/src/main/java/tech/powerjob/server/web/controller/AppInfoController.java
+++ b/powerjob-server/powerjob-server-starter/src/main/java/tech/powerjob/server/web/controller/AppInfoController.java
@@ -87,6 +87,23 @@ public class AppInfoController {
         return ResultDTO.success(convert(Lists.newArrayList(savedAppInfo), false).get(0));
     }
 
+    @PostMapping("/clone")
+    @ApiPermission(name = "App-clone", roleScope = RoleScope.APP, dynamicPermissionPlugin = ModifyOrCreateDynamicPermission.class, grandPermissionPlugin = SaveAppGrantPermissionPlugin.class)
+    public ResultDTO<AppInfoVO> cloneAppInfo(@RequestBody ModifyAppInfoRequest req, HttpServletRequest hsr) {
+        if (req.getCloneid()== null){
+            throw new PowerJobException(ErrorCodes.ILLEGAL_ARGS_ERROR, "克隆ID 不能为空");
+        }
+
+        // 安全注入攻击的场景，不信任传参
+        if (req.getId() != null) {
+            req.setId(Long.valueOf(AuthHeaderUtils.fetchAppId(hsr)));
+        }
+
+        AppInfoDO savedAppInfo = appWebService.clone(req);
+
+        return ResultDTO.success(convert(Lists.newArrayList(savedAppInfo), false).get(0));
+    }
+
     @PostMapping("/delete")
     @ApiPermission(name = "App-Delete", roleScope = RoleScope.APP, requiredPermission = Permission.SU)
     public ResultDTO<Void> deleteApp(HttpServletRequest hsr) {

--- a/powerjob-server/powerjob-server-starter/src/main/java/tech/powerjob/server/web/request/ModifyAppInfoRequest.java
+++ b/powerjob-server/powerjob-server-starter/src/main/java/tech/powerjob/server/web/request/ModifyAppInfoRequest.java
@@ -16,6 +16,7 @@ public class ModifyAppInfoRequest {
 
     private Long id;
     private String appName;
+    private Long cloneid;
 
     /**
      * namespace 唯一标识，任选其一传递即可

--- a/powerjob-server/powerjob-server-starter/src/main/java/tech/powerjob/server/web/service/impl/AppWebServiceImpl.java
+++ b/powerjob-server/powerjob-server-starter/src/main/java/tech/powerjob/server/web/service/impl/AppWebServiceImpl.java
@@ -7,28 +7,39 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.BeanUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import tech.powerjob.common.enums.ErrorCodes;
+import tech.powerjob.common.enums.SwitchableStatus;
 import tech.powerjob.common.exception.PowerJobException;
 import tech.powerjob.common.exception.PowerJobExceptionLauncher;
+import tech.powerjob.common.response.ResultDTO;
 import tech.powerjob.server.auth.LoginUserHolder;
 import tech.powerjob.server.auth.RoleScope;
+import tech.powerjob.server.auth.common.utils.AuthHeaderUtils;
 import tech.powerjob.server.auth.service.WebAuthService;
 import tech.powerjob.server.common.module.WorkerInfo;
 import tech.powerjob.server.core.service.AppInfoService;
+import tech.powerjob.server.core.service.JobService;
+import tech.powerjob.server.persistence.PageResult;
 import tech.powerjob.server.persistence.QueryConvertUtils;
 import tech.powerjob.server.persistence.remote.model.AppInfoDO;
+import tech.powerjob.server.persistence.remote.model.JobInfoDO;
 import tech.powerjob.server.persistence.remote.repository.AppInfoRepository;
+import tech.powerjob.server.persistence.remote.repository.JobInfoRepository;
 import tech.powerjob.server.remote.worker.WorkerClusterQueryService;
 import tech.powerjob.server.web.AppWebService;
 import tech.powerjob.server.web.request.ModifyAppInfoRequest;
 import tech.powerjob.server.web.request.QueryAppInfoRequest;
+import tech.powerjob.server.web.response.JobInfoVO;
 import tech.powerjob.server.web.service.NamespaceWebService;
 
+import javax.annotation.Resource;
 import javax.persistence.criteria.Predicate;
 import java.util.*;
 
@@ -45,6 +56,8 @@ public class AppWebServiceImpl implements AppWebService {
 
     private final WebAuthService webAuthService;
 
+    private final JobService jobService;
+    private final JobInfoRepository jobInfoRepository;
     private final AppInfoService appInfoService;
     private final AppInfoRepository appInfoRepository;
 
@@ -97,6 +110,62 @@ public class AppWebServiceImpl implements AppWebService {
         webAuthService.processPermissionOnSave(RoleScope.APP, savedAppInfo.getId(), req.getComponentUserRoleInfo());
         return savedAppInfo;
     }
+
+    @Override
+    public AppInfoDO clone(ModifyAppInfoRequest req) {
+        // 根据 ns code 填充 namespaceId（自动化创建过程中，固定的 namespace-code 对用户更友好）
+        if (StringUtils.isNotEmpty(req.getNamespaceCode())) {
+            namespaceWebService.findByCode(req.getNamespaceCode()).ifPresent(x -> req.setNamespaceId(x.getId()));
+        }
+
+        req.valid();
+        AppInfoDO appInfoDO;
+        Long id = req.getId();
+        if (id == null) {
+            // 前置校验，防止部分没加唯一索引的 DB 重复创建记录导致异常
+            appInfoRepository.findByAppName(req.getAppName()).ifPresent(x -> new PowerJobExceptionLauncher(ErrorCodes.ILLEGAL_ARGS_ERROR, String.format("App[%s] already exists", req.getAppName())));
+            appInfoDO = new AppInfoDO();
+            appInfoDO.setGmtCreate(new Date());
+            appInfoDO.setCreator(LoginUserHolder.getUserId());
+        } else {
+            appInfoDO = appInfoService.findById(id, false).orElseThrow(() -> new IllegalArgumentException("can't find appInfo by id:" + id));
+            // 不允许修改 appName
+            if (!appInfoDO.getAppName().equalsIgnoreCase(req.getAppName())) {
+                throw new IllegalArgumentException("NOT_ALLOW_CHANGE_THE_APP_NAME");
+            }
+        }
+        appInfoDO.setAppName(req.getAppName());
+        appInfoDO.setTitle(req.getTitle());
+        appInfoDO.setPassword(req.getPassword());
+        appInfoDO.setNamespaceId(req.getNamespaceId());
+        appInfoDO.setTags(req.getTags());
+        appInfoDO.setExtra(req.getExtra());
+        appInfoDO.setGmtModified(new Date());
+        appInfoDO.setModifier(LoginUserHolder.getUserId());
+        AppInfoDO savedAppInfo = appInfoService.save(appInfoDO);
+
+        List<JobInfoDO> jobInfoDOList = jobInfoRepository.findByAppId(req.getCloneid());
+        for (JobInfoDO origin : jobInfoDOList) {
+            if (origin.getStatus() == SwitchableStatus.DELETED.getV()) {
+                throw new IllegalStateException("can't copy the job which has been deleted!");
+            }
+            JobInfoDO copyJob = new JobInfoDO();
+            // 值拷贝
+            BeanUtils.copyProperties(origin, copyJob);
+            // 修正创建时间以及更新时间
+            copyJob.setId(null);
+            copyJob.setAppId(savedAppInfo.getId());
+            copyJob.setJobName(copyJob.getJobName());
+            copyJob.setGmtCreate(new Date());
+            copyJob.setGmtModified(new Date());
+            copyJob = jobInfoRepository.saveAndFlush(copyJob);
+        }
+        // 重新授权
+        webAuthService.processPermissionOnSave(RoleScope.APP, savedAppInfo.getId(), req.getComponentUserRoleInfo());
+        return savedAppInfo;
+    }
+
+
 
     @Override
     public void delete(Long appId) {


### PR DESCRIPTION
Brief changelog

Related Issue

添加：添加新的克隆接口，用于多appname情况下 快速新增
Changes Included
	•	Added new cloneAppName API logic.
	•	Implemented service-level method to replicate application’s display name.
	•	Added validation to ensure uniqueness of cloned name.
	•	Updated DTO and controller to support cloning parameters.
	•	Included basic UI-Level adaptation (if applicable).