### PR TITLE
fix: 修复每日定时策略的执行时间计算错误问题

### DIFF
--- a/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/scheduler/auxiliary/impl/DailyTimeIntervalStrategyHandler.java
+++ b/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/scheduler/auxiliary/impl/DailyTimeIntervalStrategyHandler.java
@@ -15,6 +15,7 @@ import tech.powerjob.server.core.scheduler.auxiliary.TimeOfDay;
 import tech.powerjob.server.core.scheduler.auxiliary.TimingStrategyHandler;
 
 import java.io.Serializable;
+import java.time.*;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Optional;
@@ -63,7 +64,8 @@ public class DailyTimeIntervalStrategyHandler implements TimingStrategyHandler {
     @SneakyThrows
     public Long calculateNextTriggerTime(Long preTriggerTime, String timeExpression, Long startTime, Long endTime) {
         DailyTimeIntervalExpress ep = JsonUtils.parseObject(timeExpression, DailyTimeIntervalExpress.class);
-
+        startTime = parseTimeStr(ep.startTimeOfDay);
+        endTime = parseTimeStr(ep.endTimeOfDay);
         // 未开始状态下，用起点算调度时间
         if (startTime != null && startTime > System.currentTimeMillis() && preTriggerTime < startTime) {
             return calculateInRangeTime(startTime, ep);
@@ -80,6 +82,11 @@ public class DailyTimeIntervalStrategyHandler implements TimingStrategyHandler {
         return null;
     }
 
+    static Long parseTimeStr(String timeStr){
+        LocalTime localTime=LocalTime.parse(timeStr);
+        ZonedDateTime zonedDateTime = localTime.atDate(LocalDate.now()).atZone(ZoneId.systemDefault());
+        return zonedDateTime.toInstant().toEpochMilli();
+    }
     /**
      * 计算最近一次在范围中的时间
      * @param time 当前时间基准，可能直接返回该时间作为结果


### PR DESCRIPTION
## What is the purpose of the change

配置一个每日定时任务，设置如下：

执行时间区间：18:00 - 19:10
切换间隔：30 分钟
当前系统时间为：17:50
此时调用获取该任务执行时间列表的逻辑，返回了错误的结果，导致任务未能在 18:00、18:30、19:00 正确触发。

## Brief changelog

修复 DailyTimeRangeScheduler（或相关调度工具类）中，当前时间早于时间窗口起点时错误执行时间计算问题

## Verifying this change

本地拉取源码，应用修改后运行上述测试用例，通过；
   
                    