### PR TITLE
fix: add @ApiPermission to detailPlus and extend SQL injection blacklist

### DIFF
--- a/powerjob-server/powerjob-server-starter/src/main/java/tech/powerjob/server/web/controller/InstanceController.java
+++ b/powerjob-server/powerjob-server-starter/src/main/java/tech/powerjob/server/web/controller/InstanceController.java
@@ -85,6 +85,7 @@ public class InstanceController {
     }
 
     @PostMapping("/detailPlus")
+    @ApiPermission(name = "Instance-DetailPlus", roleScope = RoleScope.APP, requiredPermission = Permission.READ)
     public ResultDTO<InstanceDetailVO> getInstanceDetailPlus(@RequestBody QueryInstanceDetailRequest req, HttpServletRequest hsr) {
 
         req.setAppId(AuthHeaderUtils.fetchAppIdL(hsr));
@@ -92,7 +93,7 @@ public class InstanceController {
         // 非法请求参数校验
         String customQuery = req.getCustomQuery();
         String nonNullCustomQuery = Optional.ofNullable(customQuery).orElse(OmsConstant.NONE);
-        if (StringUtils.containsAnyIgnoreCase(nonNullCustomQuery, "delete", "update", "insert", "drop", "CREATE", "ALTER", "TRUNCATE", "RENAME", "LOCK", "GRANT", "REVOKE", "PREPARE", "EXECUTE", "COMMIT", "BEGIN")) {
+        if (StringUtils.containsAnyIgnoreCase(nonNullCustomQuery, "delete", "update", "insert", "drop", "CREATE", "ALTER", "TRUNCATE", "RENAME", "LOCK", "GRANT", "REVOKE", "PREPARE", "EXECUTE", "COMMIT", "BEGIN", "RUNSCRIPT", "CALL", "LINK", "SCRIPT")) {
             throw new IllegalArgumentException("Don't get any ideas about the database, illegally query: " + customQuery);
         }
 


### PR DESCRIPTION
## 问题描述

`/instance/detailPlus` 接口存在两个安全缺陷，组合利用可实现未授权远程代码执行（Pre-Auth RCE）：

1. **缺少 `@ApiPermission` 注解**：`getInstanceDetailPlus` 方法未添加权限校验注解，导致该接口无需认证即可访问
2. **`customQuery` 参数 SQL 注入黑名单不完整**：现有黑名单遗漏了 H2 数据库特有的危险命令（`RUNSCRIPT`、`CALL`、`LINK`、`SCRIPT`），攻击者可通过这些命令执行任意代码

## 影响版本

PowerJob v5.1.0 ~ v5.1.2

## 修复内容

### 1. 强制鉴权（Patch A）
为 `getInstanceDetailPlus` 方法添加 `@ApiPermission` 注解，与其他接口（如 `getInstanceDetail`）保持一致：

```java
@PostMapping("/detailPlus")
@ApiPermission(name = "Instance-DetailPlus", roleScope = RoleScope.APP, requiredPermission = Permission.READ)
public ResultDTO<InstanceDetailVO> getInstanceDetailPlus(...)
```
### 2. 扩展黑名单（Patch B）
将 H2 特有的危险关键字加入 customQuery 过滤黑名单：
```java
StringUtils.containsAnyIgnoreCase(nonNullCustomQuery,
    ..., "RUNSCRIPT", "CALL", "LINK", "SCRIPT")
```