### PR TITLE
feat: add per-task-group thread pool isolation for lightweight tasks

### DIFF
--- a/powerjob-common/src/main/java/tech/powerjob/common/model/TaskGroupQuota.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/model/TaskGroupQuota.java
@@ -1,0 +1,43 @@
+package tech.powerjob.common.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Task group quota configuration for per-group thread pool isolation.
+ * Each task group gets its own isolated lightweight thread pool on the worker when configured.
+ *
+ * @since 2026/4/1
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskGroupQuota {
+
+    /**
+     * Default task group name. Jobs without an explicit taskGroup are assigned to this group.
+     */
+    public static final String DEFAULT_GROUP = "default";
+
+    /**
+     * Normalize a raw task group string: null/empty -> DEFAULT_GROUP, otherwise trimmed.
+     */
+    public static String normalizeTaskGroup(String raw) {
+        return (raw == null || raw.trim().isEmpty()) ? DEFAULT_GROUP : raw.trim();
+    }
+
+    /**
+     * Task group name (e.g., "payments", "reports", "default").
+     * Informational only when used in Spring Boot properties — the map key determines the group name.
+     * Required when constructing programmatically.
+     */
+    private String groupName;
+
+    /**
+     * Maximum number of lightweight task trackers for this group.
+     * Only applies to standalone CRON/API/DailyInterval jobs (lightweight tasks).
+     * Heavyweight tasks (FixedRate/FixedDelay/Broadcast/Map/MapReduce) are not affected.
+     */
+    private int maxLightweightTaskNum;
+}

--- a/powerjob-common/src/main/java/tech/powerjob/common/model/TaskGroupStatus.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/model/TaskGroupStatus.java
@@ -1,0 +1,37 @@
+package tech.powerjob.common.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Runtime status of a task group on a worker.
+ * Reported in worker heartbeat for server-side group-aware dispatch.
+ *
+ * @since 2026/4/1
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskGroupStatus {
+
+    /**
+     * Task group name
+     */
+    private String groupName;
+
+    /**
+     * Current number of running lightweight task trackers in this group
+     */
+    private int currentLightweightTaskNum;
+
+    /**
+     * Maximum lightweight task tracker capacity for this group (from TaskGroupQuota config)
+     */
+    private int maxLightweightTaskNum;
+
+    /**
+     * Whether this group is at or over capacity (currentLightweightTaskNum >= maxLightweightTaskNum)
+     */
+    private boolean overloaded;
+}

--- a/powerjob-common/src/main/java/tech/powerjob/common/request/ServerScheduleJobReq.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/request/ServerScheduleJobReq.java
@@ -107,4 +107,10 @@ public class ServerScheduleJobReq implements PowerSerializable {
      * 调度元信息
      */
     private String meta;
+
+    /**
+     * Task group for per-group thread pool isolation on the worker.
+     * Null/empty means "default" group.
+     */
+    private String taskGroup;
 }

--- a/powerjob-common/src/main/java/tech/powerjob/common/request/WorkerHeartbeat.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/request/WorkerHeartbeat.java
@@ -3,6 +3,7 @@ package tech.powerjob.common.request;
 import tech.powerjob.common.PowerSerializable;
 import tech.powerjob.common.model.DeployedContainerInfo;
 import tech.powerjob.common.model.SystemMetrics;
+import tech.powerjob.common.model.TaskGroupStatus;
 import lombok.Data;
 
 import java.util.List;
@@ -68,4 +69,10 @@ public class WorkerHeartbeat implements PowerSerializable {
 
 
     private SystemMetrics systemMetrics;
+
+    /**
+     * Per-group task tracker status for group-aware dispatch.
+     * Null for legacy workers without group isolation configured.
+     */
+    private List<TaskGroupStatus> taskGroupStatuses;
 }

--- a/powerjob-common/src/main/java/tech/powerjob/common/request/http/SaveJobInfoRequest.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/request/http/SaveJobInfoRequest.java
@@ -152,6 +152,13 @@ public class SaveJobInfoRequest {
     private String tag;
 
     /**
+     * Task group for per-group thread pool isolation on workers.
+     * Jobs with the same taskGroup share an isolated thread pool.
+     * Null/empty means "default" group.
+     */
+    private String taskGroup;
+
+    /**
      * 日志配置，包括日志级别、日志方式等配置信息
      */
     private LogConfig logConfig;
@@ -171,6 +178,16 @@ public class SaveJobInfoRequest {
         CommonUtils.requireNonNull(executeType, "executeType can't be empty");
         CommonUtils.requireNonNull(processorType, "processorType can't be empty");
         CommonUtils.requireNonNull(timeExpressionType, "timeExpressionType can't be empty");
+
+        // taskGroup is only supported for lightweight tasks (standalone + non-frequent)
+        if (taskGroup != null && !taskGroup.trim().isEmpty()) {
+            if (executeType != ExecuteType.STANDALONE) {
+                throw new IllegalArgumentException("taskGroup is only supported for STANDALONE execution mode, not " + executeType);
+            }
+            if (timeExpressionType == TimeExpressionType.FIXED_RATE || timeExpressionType == TimeExpressionType.FIXED_DELAY) {
+                throw new IllegalArgumentException("taskGroup is only supported for lightweight tasks, not " + timeExpressionType);
+            }
+        }
     }
 
     public DispatchStrategy getDispatchStrategy() {

--- a/powerjob-common/src/main/java/tech/powerjob/common/response/JobInfoDTO.java
+++ b/powerjob-common/src/main/java/tech/powerjob/common/response/JobInfoDTO.java
@@ -141,6 +141,11 @@ public class JobInfoDTO {
     private String tag;
 
     /**
+     * Task group for per-group thread pool isolation on workers.
+     */
+    private String taskGroup;
+
+    /**
      * 日志配置，包括日志级别、日志方式等配置信息
      */
     private LogConfig logConfig;

--- a/powerjob-server/powerjob-server-common/src/main/java/tech/powerjob/server/common/module/WorkerInfo.java
+++ b/powerjob-server/powerjob-server-common/src/main/java/tech/powerjob/server/common/module/WorkerInfo.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import tech.powerjob.common.model.DeployedContainerInfo;
 import tech.powerjob.common.model.SystemMetrics;
+import tech.powerjob.common.model.TaskGroupStatus;
 import tech.powerjob.common.request.WorkerHeartbeat;
 
 import java.util.List;
@@ -47,6 +48,14 @@ public class WorkerInfo {
 
     private List<DeployedContainerInfo> containerInfos;
 
+    /**
+     * Per-group task tracker status reported in heartbeat.
+     * Null for legacy workers without group isolation configured.
+     * Marked volatile to ensure visibility across the heartbeat-processing thread
+     * and dispatch threads that call overloadForGroup().
+     */
+    private volatile List<TaskGroupStatus> taskGroupStatuses;
+
     private static final long WORKER_TIMEOUT_MS = 60000;
 
     public void refresh(WorkerHeartbeat workerHeartbeat) {
@@ -61,6 +70,7 @@ public class WorkerInfo {
 
         lightTaskTrackerNum = workerHeartbeat.getLightTaskTrackerNum();
         heavyTaskTrackerNum = workerHeartbeat.getHeavyTaskTrackerNum();
+        taskGroupStatuses = workerHeartbeat.getTaskGroupStatuses();
 
         if (workerHeartbeat.isOverload()) {
             overloading = true;
@@ -77,6 +87,26 @@ public class WorkerInfo {
     }
 
     public boolean overload() {
+        return overloading;
+    }
+
+    /**
+     * Check if this worker is overloaded for a specific task group.
+     * Falls back to the global overload flag for legacy workers or unknown groups.
+     */
+    public boolean overloadForGroup(String groupName) {
+        // Snapshot the volatile reference to avoid races with refresh()
+        List<TaskGroupStatus> snapshot = taskGroupStatuses;
+        if (snapshot == null || snapshot.isEmpty()) {
+            // Legacy worker without group isolation: use global overload flag
+            return overloading;
+        }
+        for (TaskGroupStatus status : snapshot) {
+            if (status.getGroupName() != null && status.getGroupName().equals(groupName)) {
+                return status.isOverloaded();
+            }
+        }
+        // Unknown group on this worker: fall back to global overload flag
         return overloading;
     }
 }

--- a/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/DispatchService.java
+++ b/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/DispatchService.java
@@ -13,6 +13,7 @@ import tech.powerjob.common.enums.ExecuteType;
 import tech.powerjob.common.enums.InstanceStatus;
 import tech.powerjob.common.enums.ProcessorType;
 import tech.powerjob.common.enums.TimeExpressionType;
+import tech.powerjob.common.model.TaskGroupQuota;
 import tech.powerjob.common.request.ServerScheduleJobReq;
 import tech.powerjob.remote.framework.base.URL;
 import tech.powerjob.server.common.Holder;
@@ -157,8 +158,13 @@ public class DispatchService {
             instanceManager.processFinishedInstance(instanceId, instanceInfo.getWfInstanceId(), FAILED, SystemInstanceResult.NO_WORKER_AVAILABLE);
             return;
         }
-        // 判断是否超载，在所有可用 worker 超载的情况下直接跳过当前任务
-        suitableWorkers = filterOverloadWorker(suitableWorkers);
+        // 判断是否超载 — group-aware only for lightweight tasks, global for heavyweight
+        if (isLightweightTask(jobInfo)) {
+            String taskGroup = normalizeTaskGroup(jobInfo.getTaskGroup());
+            suitableWorkers = filterOverloadWorker(suitableWorkers, taskGroup);
+        } else {
+            suitableWorkers = filterOverloadWorker(suitableWorkers);
+        }
         if (suitableWorkers.isEmpty()) {
             // 直接取消派发，减少一次数据库 io
             overloadOptional.ifPresent(booleanHolder -> booleanHolder.set(true));
@@ -183,16 +189,51 @@ public class DispatchService {
         instanceMetadataService.loadJobInfo(instanceId, jobInfo);
     }
 
+    /**
+     * Filter overloaded workers using global overload flag (original behavior).
+     * Used for heavyweight tasks (Broadcast/Map/MapReduce/FixedRate/FixedDelay).
+     */
     private List<WorkerInfo> filterOverloadWorker(List<WorkerInfo> suitableWorkers) {
-
         List<WorkerInfo> res = new ArrayList<>(suitableWorkers.size());
         for (WorkerInfo suitableWorker : suitableWorkers) {
-            if (suitableWorker.overload()){
+            if (suitableWorker.overload()) {
                 continue;
             }
             res.add(suitableWorker);
         }
         return res;
+    }
+
+    /**
+     * Filter overloaded workers using per-group overload status.
+     * Used for lightweight tasks (standalone CRON/API/DailyInterval/Workflow).
+     * Falls back to global overload for legacy workers without group reporting.
+     */
+    private List<WorkerInfo> filterOverloadWorker(List<WorkerInfo> suitableWorkers, String taskGroup) {
+        List<WorkerInfo> res = new ArrayList<>(suitableWorkers.size());
+        for (WorkerInfo suitableWorker : suitableWorkers) {
+            if (suitableWorker.overloadForGroup(taskGroup)) {
+                continue;
+            }
+            res.add(suitableWorker);
+        }
+        return res;
+    }
+
+    /**
+     * Determine if a job is a lightweight task (same logic as worker-side TaskTrackerActor.isLightweightTask).
+     * Lightweight = standalone execution AND not fixed-rate/fixed-delay.
+     */
+    private static boolean isLightweightTask(JobInfoDO jobInfo) {
+        ExecuteType executeType = ExecuteType.of(jobInfo.getExecuteType());
+        if (executeType != ExecuteType.STANDALONE) {
+            return false;
+        }
+        return !TimeExpressionType.FREQUENT_TYPES.contains(jobInfo.getTimeExpressionType());
+    }
+
+    private static String normalizeTaskGroup(String raw) {
+        return TaskGroupQuota.normalizeTaskGroup(raw);
     }
 
     /**
@@ -230,6 +271,15 @@ public class DispatchService {
         }
         req.setThreadConcurrency(jobInfo.getConcurrency());
         req.setMeta(instanceInfo.getMeta());
+
+        // Set task group only for lightweight tasks (heavyweight tasks don't support group isolation).
+        // BeanUtils.copyProperties may have copied taskGroup from jobInfo — override explicitly.
+        if (isLightweightTask(jobInfo)) {
+            req.setTaskGroup(normalizeTaskGroup(jobInfo.getTaskGroup()));
+        } else {
+            req.setTaskGroup(null);
+        }
+
         return req;
     }
 }

--- a/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/scheduler/InstanceStatusCheckService.java
+++ b/powerjob-server/powerjob-server-core/src/main/java/tech/powerjob/server/core/scheduler/InstanceStatusCheckService.java
@@ -8,8 +8,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import tech.powerjob.common.SystemInstanceResult;
+import tech.powerjob.common.enums.ExecuteType;
 import tech.powerjob.common.enums.InstanceStatus;
 import tech.powerjob.common.enums.TimeExpressionType;
+import tech.powerjob.common.model.TaskGroupQuota;
 import tech.powerjob.common.enums.WorkflowInstanceStatus;
 import tech.powerjob.server.common.Holder;
 import tech.powerjob.common.enums.SwitchableStatus;
@@ -166,25 +168,48 @@ public class InstanceStatusCheckService {
                 // query job info and map
                 Map<Long, JobInfoDO> jobInfoMap = jobInfoRepository.findByIdIn(jobIds).stream().collect(Collectors.toMap(JobInfoDO::getId, e -> e));
                 log.warn("[InstanceStatusChecker] find some instance in app({}) which is not triggered as expected: {}", currentAppId, currentAppWaitingDispatchInstances.stream().map(InstanceInfoDO::getInstanceId).collect(Collectors.toList()));
-                final Holder<Boolean> overloadFlag = new Holder<>(false);
+                // Track overloaded lightweight groups to skip subsequent lightweight tasks in the same group.
+                // Heavyweight tasks use heavyOverloadFlag for early-exit (preserves original behavior).
+                // App-level blacklist only triggers on heavyweight overload (not lightweight group overload),
+                // because a single lightweight group being full should not block other groups or heavyweight tasks.
+                final Set<String> overloadedLightGroups = java.util.concurrent.ConcurrentHashMap.newKeySet();
+                final Holder<Boolean> heavyOverloadFlag = new Holder<>(false);
                 // 先这么简单处理没问题，毕竟只有这一个地方用了 parallelStream
                 currentAppWaitingDispatchInstances.parallelStream().forEach(instance -> {
-                    if (overloadFlag.get()) {
-                        // 直接忽略
-                        return;
-                    }
                     Optional<JobInfoDO> jobInfoOpt = Optional.ofNullable(jobInfoMap.get(instance.getJobId()));
-                    if (jobInfoOpt.isPresent()) {
-                        // 处理等待派发的任务没有必要再重置一次状态，减少 io 次数
-                        dispatchService.dispatch(jobInfoOpt.get(), instance.getInstanceId(), Optional.of(instance), Optional.of(overloadFlag));
-                    } else {
+                    if (!jobInfoOpt.isPresent()) {
                         log.warn("[InstanceStatusChecker] can't find job by jobId[{}], so redispatch failed, failed instance: {}", instance.getJobId(), instance);
                         final Optional<InstanceInfoDO> opt = instanceInfoRepository.findById(instance.getId());
                         opt.ifPresent(instanceInfoDO -> updateFailedInstance(instanceInfoDO, SystemInstanceResult.CAN_NOT_FIND_JOB_INFO));
+                        return;
+                    }
+                    JobInfoDO jobForInstance = jobInfoOpt.get();
+                    boolean lightweight = isLightweightTask(jobForInstance);
+                    if (lightweight) {
+                        String taskGroup = normalizeTaskGroup(jobForInstance.getTaskGroup());
+                        if (overloadedLightGroups.contains(taskGroup)) {
+                            return;
+                        }
+                    } else {
+                        if (heavyOverloadFlag.get()) {
+                            return;
+                        }
+                    }
+                    final Holder<Boolean> instanceOverloadFlag = new Holder<>(false);
+                    // 处理等待派发的任务没有必要再重置一次状态，减少 io 次数
+                    dispatchService.dispatch(jobForInstance, instance.getInstanceId(), Optional.of(instance), Optional.of(instanceOverloadFlag));
+                    if (instanceOverloadFlag.get()) {
+                        if (lightweight) {
+                            overloadedLightGroups.add(normalizeTaskGroup(jobForInstance.getTaskGroup()));
+                        } else {
+                            heavyOverloadFlag.set(true);
+                        }
                     }
                 });
                 threshold = System.currentTimeMillis() - DISPATCH_TIMEOUT_MS;
-                if (overloadFlag.get()) {
+                // Only blacklist the app when heavyweight tasks are overloaded (original behavior).
+                // Lightweight group overload is handled per-group above, not at app level.
+                if (heavyOverloadFlag.get()) {
                     overloadAppIdList.add(currentAppId);
                 }
             }
@@ -282,6 +307,18 @@ public class InstanceStatusCheckService {
                 });
             }
         });
+    }
+
+    private static boolean isLightweightTask(JobInfoDO jobInfo) {
+        ExecuteType executeType = ExecuteType.of(jobInfo.getExecuteType());
+        if (executeType != ExecuteType.STANDALONE) {
+            return false;
+        }
+        return !TimeExpressionType.FREQUENT_TYPES.contains(jobInfo.getTimeExpressionType());
+    }
+
+    private static String normalizeTaskGroup(String raw) {
+        return TaskGroupQuota.normalizeTaskGroup(raw);
     }
 
     /**

--- a/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/remote/model/JobInfoDO.java
+++ b/powerjob-server/powerjob-server-persistence/src/main/java/tech/powerjob/server/persistence/remote/model/JobInfoDO.java
@@ -160,6 +160,13 @@ public class JobInfoDO {
     private String tag;
 
     /**
+     * Task group for per-group thread pool isolation on workers.
+     * Jobs with the same taskGroup share an isolated lightweight thread pool.
+     * Null/empty means "default" group.
+     */
+    private String taskGroup;
+
+    /**
      * 日志配置，包括日志级别、日志方式等配置信息
      */
     private String logConfig;

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobAutoConfiguration.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobAutoConfiguration.java
@@ -85,6 +85,9 @@ public class PowerJobAutoConfiguration {
         config.setMaxLightweightTaskNum(worker.getMaxLightweightTaskNum());
 
         config.setHealthReportInterval(worker.getHealthReportInterval());
+
+        config.setTaskGroupQuotas(worker.getTaskGroupQuotas());
+
         /*
          * Create PowerJobSpringWorker object and set properties.
          */

--- a/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobProperties.java
+++ b/powerjob-worker-spring-boot-starter/src/main/java/tech/powerjob/worker/autoconfigure/PowerJobProperties.java
@@ -2,6 +2,7 @@ package tech.powerjob.worker.autoconfigure;
 
 import tech.powerjob.common.RemoteConstant;
 import tech.powerjob.common.enums.Protocol;
+import tech.powerjob.common.model.TaskGroupQuota;
 import tech.powerjob.worker.common.constants.StoreStrategy;
 import tech.powerjob.worker.core.processor.ProcessResult;
 import tech.powerjob.worker.core.processor.WorkflowContext;
@@ -9,6 +10,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
+
+import java.util.Map;
 
 /**
  * PowerJob properties configuration class.
@@ -169,6 +172,25 @@ public class PowerJobProperties {
          * Interval(s) of worker health report
          */
         private Integer healthReportInterval = 10;
+
+        /**
+         * Per-group task quotas for lightweight thread pool isolation.
+         * When null or empty, the worker operates in legacy mode (single flat pool).
+         * A "default" group MUST be present. Sum of all group quotas must be <= maxLightweightTaskNum.
+         * Example YAML:
+         * <pre>
+         * powerjob:
+         *   worker:
+         *     task-group-quotas:
+         *       payments:
+         *         max-lightweight-task-num: 200
+         *       reports:
+         *         max-lightweight-task-num: 300
+         *       default:
+         *         max-lightweight-task-num: 524
+         * </pre>
+         */
+        private Map<String, TaskGroupQuota> taskGroupQuotas;
 
     }
 }

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/actors/TaskTrackerActor.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/actors/TaskTrackerActor.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import tech.powerjob.common.enums.ExecuteType;
 import tech.powerjob.common.enums.TimeExpressionType;
 import tech.powerjob.common.model.InstanceDetail;
+import tech.powerjob.common.model.TaskGroupQuota;
 import tech.powerjob.common.request.ServerQueryInstanceStatusReq;
 import tech.powerjob.common.request.ServerScheduleJobReq;
 import tech.powerjob.common.request.ServerStopInstanceReq;
@@ -22,6 +23,8 @@ import tech.powerjob.worker.persistence.TaskDO;
 import tech.powerjob.worker.pojo.request.ProcessorMapTaskRequest;
 import tech.powerjob.worker.pojo.request.ProcessorReportTaskStatusReq;
 import tech.powerjob.worker.pojo.request.ProcessorTrackerStatusReportReq;
+
+import java.util.Map;
 
 import java.util.List;
 
@@ -129,17 +132,44 @@ public class TaskTrackerActor {
                 log.warn("[TaskTrackerActor] LightTaskTracker({}) for instance(id={}) already exists.", taskTracker, instanceId);
                 return;
             }
-            // 判断是否已经 overload
-            if (LightTaskTrackerManager.currentTaskTrackerSize() >= workerRuntime.getWorkerConfig().getMaxLightweightTaskNum() * LightTaskTrackerManager.OVERLOAD_FACTOR) {
-                // ignore this request
-                log.warn("[TaskTrackerActor] this worker is overload,ignore this request(instanceId={}),current size = {}!",instanceId,LightTaskTrackerManager.currentTaskTrackerSize());
-                return;
+
+            // Normalize task group
+            final String taskGroup = normalizeTaskGroup(req.getTaskGroup());
+
+            // 判断是否已经 overload — group-aware if configured
+            Map<String, TaskGroupQuota> quotas = workerRuntime.getWorkerConfig().getTaskGroupQuotas();
+            if (quotas != null && !quotas.isEmpty()) {
+                // Per-group capacity check
+                TaskGroupQuota quota = quotas.get(taskGroup);
+                if (quota == null) {
+                    // Unknown group: fall back to "default"
+                    quota = quotas.get(TaskGroupQuota.DEFAULT_GROUP);
+                    log.warn("[TaskTrackerActor] unknown taskGroup '{}', falling back to 'default' group for instanceId={}", taskGroup, instanceId);
+                }
+                int groupMax = quota != null ? quota.getMaxLightweightTaskNum() : workerRuntime.getWorkerConfig().getMaxLightweightTaskNum();
+                int groupSize = LightTaskTrackerManager.currentTaskTrackerSizeByGroup(taskGroup);
+                if (groupSize >= groupMax * LightTaskTrackerManager.OVERLOAD_FACTOR) {
+                    log.warn("[TaskTrackerActor] taskGroup '{}' is overloaded, ignore request(instanceId={}), current group size = {}, group max = {}!",
+                            taskGroup, instanceId, groupSize, groupMax);
+                    return;
+                }
+                if (groupSize >= groupMax) {
+                    log.warn("[TaskTrackerActor] taskGroup '{}' will be overloaded soon, current group size = {}, group max = {}!",
+                            taskGroup, groupSize, groupMax);
+                }
+            } else {
+                // Legacy mode: global capacity check (unchanged behavior)
+                if (LightTaskTrackerManager.currentTaskTrackerSize() >= workerRuntime.getWorkerConfig().getMaxLightweightTaskNum() * LightTaskTrackerManager.OVERLOAD_FACTOR) {
+                    log.warn("[TaskTrackerActor] this worker is overload, ignore this request(instanceId={}), current size = {}!",
+                            instanceId, LightTaskTrackerManager.currentTaskTrackerSize());
+                    return;
+                }
+                if (LightTaskTrackerManager.currentTaskTrackerSize() >= workerRuntime.getWorkerConfig().getMaxLightweightTaskNum()) {
+                    log.warn("[TaskTrackerActor] this worker will be overload soon, current size = {}!", LightTaskTrackerManager.currentTaskTrackerSize());
+                }
             }
-            if (LightTaskTrackerManager.currentTaskTrackerSize() >= workerRuntime.getWorkerConfig().getMaxLightweightTaskNum()) {
-                log.warn("[TaskTrackerActor] this worker will be overload soon,current size = {}!",LightTaskTrackerManager.currentTaskTrackerSize());
-            }
-            // 创建轻量级任务
-            LightTaskTrackerManager.atomicCreateTaskTracker(instanceId, ignore -> LightTaskTracker.create(req, workerRuntime));
+            // 创建轻量级任务 with group tracking
+            LightTaskTrackerManager.atomicCreateTaskTracker(instanceId, taskGroup, ignore -> LightTaskTracker.create(req, workerRuntime));
         } else {
             HeavyTaskTracker taskTracker = HeavyTaskTrackerManager.getTaskTracker(instanceId);
             if (taskTracker != null) {
@@ -208,6 +238,10 @@ public class TaskTrackerActor {
         return askResponse;
     }
 
+
+    private static String normalizeTaskGroup(String raw) {
+        return TaskGroupQuota.normalizeTaskGroup(raw);
+    }
 
     private boolean isLightweightTask(ServerScheduleJobReq serverScheduleJobReq) {
         final ExecuteType executeType = ExecuteType.valueOf(serverScheduleJobReq.getExecuteType());

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/background/heartbeat/WorkerHealthReporter.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/background/heartbeat/WorkerHealthReporter.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import tech.powerjob.common.enhance.SafeRunnable;
 import tech.powerjob.common.model.SystemMetrics;
+import tech.powerjob.common.model.TaskGroupQuota;
+import tech.powerjob.common.model.TaskGroupStatus;
 import tech.powerjob.common.request.WorkerHeartbeat;
 import tech.powerjob.worker.common.PowerJobWorkerVersion;
 import tech.powerjob.worker.common.WorkerRuntime;
@@ -12,6 +14,10 @@ import tech.powerjob.worker.common.utils.TransportUtils;
 import tech.powerjob.worker.container.OmsContainerFactory;
 import tech.powerjob.worker.core.tracker.manager.HeavyTaskTrackerManager;
 import tech.powerjob.worker.core.tracker.manager.LightTaskTrackerManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -55,10 +61,24 @@ public class WorkerHealthReporter extends SafeRunnable {
         // 上报 Tracker 数量
         heartbeat.setLightTaskTrackerNum(LightTaskTrackerManager.currentTaskTrackerSize());
         heartbeat.setHeavyTaskTrackerNum(HeavyTaskTrackerManager.currentTaskTrackerSize());
-        // 是否超载
+        // 是否超载 (global check — backward compatible)
         if (workerRuntime.getWorkerConfig().getMaxLightweightTaskNum() <= LightTaskTrackerManager.currentTaskTrackerSize() || workerRuntime.getWorkerConfig().getMaxHeavyweightTaskNum() <= HeavyTaskTrackerManager.currentTaskTrackerSize()){
             heartbeat.setOverload(true);
         }
+
+        // Per-group status reporting for group-aware dispatch
+        Map<String, TaskGroupQuota> quotas = workerRuntime.getWorkerConfig().getTaskGroupQuotas();
+        if (quotas != null && !quotas.isEmpty()) {
+            List<TaskGroupStatus> groupStatuses = new ArrayList<>();
+            for (Map.Entry<String, TaskGroupQuota> entry : quotas.entrySet()) {
+                String groupName = entry.getKey();
+                int maxTasks = entry.getValue().getMaxLightweightTaskNum();
+                int currentTasks = LightTaskTrackerManager.currentTaskTrackerSizeByGroup(groupName);
+                groupStatuses.add(new TaskGroupStatus(groupName, currentTasks, maxTasks, currentTasks >= maxTasks));
+            }
+            heartbeat.setTaskGroupStatuses(groupStatuses);
+        }
+
         // 获取当前加载的容器列表
         heartbeat.setContainerInfos(OmsContainerFactory.getDeployedContainerInfos());
         // 发送请求

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/common/PowerJobWorkerConfig.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/common/PowerJobWorkerConfig.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import tech.powerjob.common.RemoteConstant;
 import tech.powerjob.common.enums.Protocol;
+import tech.powerjob.common.model.TaskGroupQuota;
 import tech.powerjob.worker.common.constants.StoreStrategy;
 import tech.powerjob.worker.core.processor.ProcessResult;
 import tech.powerjob.worker.core.processor.WorkflowContext;
@@ -12,6 +13,7 @@ import tech.powerjob.worker.extension.SystemMetricsCollector;
 import tech.powerjob.worker.extension.processor.ProcessorFactory;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * The powerjob-worker's configuration
@@ -80,6 +82,14 @@ public class PowerJobWorkerConfig {
      * Max numbers of LightTaskTacker
      */
     private Integer maxLightweightTaskNum = 1024;
+
+    /**
+     * Per-group task quotas for lightweight thread pool isolation.
+     * When null or empty, the worker operates in legacy mode (single flat pool).
+     * When configured, each group gets its own isolated ThreadPoolExecutor.
+     * A "default" group MUST be present. Sum of all group quotas must be <= maxLightweightTaskNum.
+     */
+    private Map<String, TaskGroupQuota> taskGroupQuotas;
     /**
      * Max numbers of HeavyTaskTacker
      */

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/core/executor/ExecutorManager.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/core/executor/ExecutorManager.java
@@ -2,15 +2,20 @@ package tech.powerjob.worker.core.executor;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import tech.powerjob.common.model.TaskGroupQuota;
 import tech.powerjob.common.utils.SysUtils;
 import tech.powerjob.worker.common.PowerJobWorkerConfig;
+import tech.powerjob.worker.core.tracker.manager.LightTaskTrackerManager;
 
+import java.util.Map;
 import java.util.concurrent.*;
 
 /**
  * @author Echo009
  * @since 2022/9/23
  */
+@Slf4j
 @Getter
 public class ExecutorManager {
     /**
@@ -22,34 +27,139 @@ public class ExecutorManager {
      */
     private final ScheduledExecutorService lightweightTaskStatusCheckExecutor;
     /**
-     * 执行轻量级任务
+     * 执行轻量级任务 (default/fallback pool)
      */
     private final ExecutorService lightweightTaskExecutorService;
 
+    /**
+     * Per-group lightweight task executors. Null when task group isolation is not configured.
+     */
+    private final Map<String, ExecutorService> groupLightweightExecutors;
 
-    public ExecutorManager(PowerJobWorkerConfig workerConfig){
 
+    public ExecutorManager(PowerJobWorkerConfig workerConfig) {
 
         final int availableProcessors = SysUtils.availableProcessors();
         // 初始化定时线程池
         ThreadFactory coreThreadFactory = new ThreadFactoryBuilder().setNameFormat("powerjob-worker-core-%d").build();
-        coreExecutor =  new ScheduledThreadPoolExecutor(3, coreThreadFactory);
+        coreExecutor = new ScheduledThreadPoolExecutor(3, coreThreadFactory);
 
         ThreadFactory lightTaskReportFactory = new ThreadFactoryBuilder().setNameFormat("powerjob-worker-light-task-status-check-%d").build();
         // 都是 io 密集型任务
-        lightweightTaskStatusCheckExecutor =  new ScheduledThreadPoolExecutor(availableProcessors * 10, lightTaskReportFactory);
+        lightweightTaskStatusCheckExecutor = new ScheduledThreadPoolExecutor(availableProcessors * 10, lightTaskReportFactory);
 
         ThreadFactory lightTaskExecuteFactory = new ThreadFactoryBuilder().setNameFormat("powerjob-worker-light-task-execute-%d").build();
         // 大部分任务都是 io 密集型
-        lightweightTaskExecutorService = new ThreadPoolExecutor(availableProcessors * 10,availableProcessors * 10, 120L, TimeUnit.SECONDS,
-                new ArrayBlockingQueue<>((workerConfig.getMaxLightweightTaskNum() * 2),true), lightTaskExecuteFactory, new ThreadPoolExecutor.AbortPolicy());
+        lightweightTaskExecutorService = new ThreadPoolExecutor(availableProcessors * 10, availableProcessors * 10, 120L, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>((workerConfig.getMaxLightweightTaskNum() * 2), true), lightTaskExecuteFactory, new ThreadPoolExecutor.AbortPolicy());
 
+        // Initialize per-group executors if configured
+        Map<String, TaskGroupQuota> quotas = workerConfig.getTaskGroupQuotas();
+        if (quotas != null && !quotas.isEmpty()) {
+            validateTaskGroupQuotas(workerConfig);
+            groupLightweightExecutors = new ConcurrentHashMap<>();
+            int totalProcessors = availableProcessors * 10; // same as global pool core size
+            int totalQuota = quotas.values().stream().mapToInt(TaskGroupQuota::getMaxLightweightTaskNum).sum();
+
+            for (Map.Entry<String, TaskGroupQuota> entry : quotas.entrySet()) {
+                String groupName = entry.getKey();
+                TaskGroupQuota quota = entry.getValue();
+
+                // Scale thread count proportionally to quota ratio
+                int groupThreads = Math.max(1, (int) Math.round((double) quota.getMaxLightweightTaskNum() / totalQuota * totalProcessors));
+                int queueSize = quota.getMaxLightweightTaskNum() * 2;
+
+                ThreadFactory groupFactory = new ThreadFactoryBuilder()
+                        .setNameFormat("powerjob-light-group-" + groupName + "-%d")
+                        .build();
+
+                ExecutorService groupExecutor = new ThreadPoolExecutor(
+                        groupThreads, groupThreads, 120L, TimeUnit.SECONDS,
+                        new ArrayBlockingQueue<>(queueSize, true),
+                        groupFactory,
+                        new ThreadPoolExecutor.AbortPolicy()
+                );
+
+                groupLightweightExecutors.put(groupName, groupExecutor);
+                log.info("[ExecutorManager] created group executor: group={}, threads={}, queueSize={}, maxTasks={}",
+                        groupName, groupThreads, queueSize, quota.getMaxLightweightTaskNum());
+            }
+        } else {
+            groupLightweightExecutors = null;
+        }
+    }
+
+    /**
+     * Get the executor for a specific task group. Falls back to the default global pool
+     * if groups are not configured or the group is unknown.
+     */
+    public ExecutorService getGroupLightweightTaskExecutorService(String groupName) {
+        if (groupLightweightExecutors == null) {
+            return lightweightTaskExecutorService;
+        }
+        ExecutorService executor = groupLightweightExecutors.get(groupName);
+        if (executor != null) {
+            return executor;
+        }
+        // Unknown group: fall back to "default" group, then to global pool
+        executor = groupLightweightExecutors.get(TaskGroupQuota.DEFAULT_GROUP);
+        if (executor != null) {
+            log.warn("[ExecutorManager] unknown taskGroup '{}', falling back to 'default' group", groupName);
+            return executor;
+        }
+        return lightweightTaskExecutorService;
+    }
+
+    /**
+     * Validate task group quota configuration at startup.
+     */
+    private void validateTaskGroupQuotas(PowerJobWorkerConfig config) {
+        Map<String, TaskGroupQuota> quotas = config.getTaskGroupQuotas();
+
+        if (!quotas.containsKey(TaskGroupQuota.DEFAULT_GROUP)) {
+            throw new IllegalArgumentException(
+                    "[ExecutorManager] taskGroupQuotas must contain a 'default' group. " +
+                    "The 'default' group handles all jobs without an explicit taskGroup and jobs with unknown groups.");
+        }
+
+        int totalQuota = 0;
+        for (Map.Entry<String, TaskGroupQuota> entry : quotas.entrySet()) {
+            if (entry.getValue().getMaxLightweightTaskNum() <= 0) {
+                throw new IllegalArgumentException(
+                        "[ExecutorManager] group '" + entry.getKey() + "' maxLightweightTaskNum must be > 0");
+            }
+            totalQuota += entry.getValue().getMaxLightweightTaskNum();
+        }
+
+        if (totalQuota > config.getMaxLightweightTaskNum()) {
+            throw new IllegalArgumentException(
+                    "[ExecutorManager] sum of group quotas (" + totalQuota +
+                    ") exceeds maxLightweightTaskNum (" + config.getMaxLightweightTaskNum() +
+                    "). Reduce group quotas or increase maxLightweightTaskNum.");
+        }
+
+        if (totalQuota < config.getMaxLightweightTaskNum()) {
+            log.warn("[ExecutorManager] sum of group quotas ({}) is less than maxLightweightTaskNum ({}). {} task slots are unallocated.",
+                    totalQuota, config.getMaxLightweightTaskNum(), config.getMaxLightweightTaskNum() - totalQuota);
+        }
     }
 
 
-
-    public void shutdown(){
+    public void shutdown() {
         coreExecutor.shutdownNow();
+        lightweightTaskExecutorService.shutdownNow();
+        lightweightTaskStatusCheckExecutor.shutdownNow();
+
+        // Shut down per-group executors
+        if (groupLightweightExecutors != null) {
+            groupLightweightExecutors.forEach((group, executor) -> {
+                log.info("[ExecutorManager] shutting down group executor: {}", group);
+                executor.shutdownNow();
+            });
+        }
+
+        // Clear static tracking maps
+        LightTaskTrackerManager.clearAll();
     }
 
 }

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/core/tracker/manager/LightTaskTrackerManager.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/core/tracker/manager/LightTaskTrackerManager.java
@@ -1,9 +1,12 @@
 package tech.powerjob.worker.core.tracker.manager;
 
 import com.google.common.collect.Maps;
+import tech.powerjob.common.model.TaskGroupQuota;
 import tech.powerjob.worker.core.tracker.task.light.LightTaskTracker;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
@@ -16,24 +19,76 @@ public class LightTaskTrackerManager {
 
     private static final Map<Long, LightTaskTracker> INSTANCE_ID_2_TASK_TRACKER = Maps.newConcurrentMap();
 
+    /**
+     * Per-group index: groupName -> set of instanceIds belonging to that group.
+     * Used for per-group capacity checking and heartbeat reporting.
+     */
+    private static final ConcurrentHashMap<String, Set<Long>> GROUP_2_INSTANCE_IDS = new ConcurrentHashMap<>();
+
 
     public static LightTaskTracker getTaskTracker(Long instanceId) {
         return INSTANCE_ID_2_TASK_TRACKER.get(instanceId);
     }
 
     public static void removeTaskTracker(Long instanceId) {
-        // 忽略印度的 IDE 警告，这个判断非常有用！！！不加这个判断会导致：如果创建 TT（先执行 computeIfAbsent 正在将TT添加到 HashMap） 时报错，TT 主动调用 destroy 销毁（从 HashMap移除该 TT）时死锁
+        // 忽略 IDE 警告，这个判断非常有用！不加这个判断会导致：如果创建 TT（先执行 computeIfAbsent 正在将TT添加到 HashMap） 时报错，TT 主动调用 destroy 销毁（从 HashMap移除该 TT）时死锁
         if (INSTANCE_ID_2_TASK_TRACKER.containsKey(instanceId)) {
-            INSTANCE_ID_2_TASK_TRACKER.remove(instanceId);
+            LightTaskTracker tracker = INSTANCE_ID_2_TASK_TRACKER.remove(instanceId);
+            // Clean up group index using the group stored in the tracker
+            if (tracker != null) {
+                String group = tracker.getTaskGroup();
+                if (group != null) {
+                    GROUP_2_INSTANCE_IDS.compute(group, (k, set) -> {
+                        if (set == null) return null;
+                        set.remove(instanceId);
+                        return set.isEmpty() ? null : set;
+                    });
+                }
+            }
         }
     }
 
+    /**
+     * Create a task tracker with group tracking (legacy signature without group — uses "default").
+     */
     public static void atomicCreateTaskTracker(Long instanceId, Function<Long, LightTaskTracker> creator) {
-        INSTANCE_ID_2_TASK_TRACKER.computeIfAbsent(instanceId, creator);
+        atomicCreateTaskTracker(instanceId, TaskGroupQuota.DEFAULT_GROUP, creator);
     }
 
-    public static int currentTaskTrackerSize(){
+    /**
+     * Create a task tracker and register it in the per-group index.
+     */
+    public static void atomicCreateTaskTracker(Long instanceId, String groupName, Function<Long, LightTaskTracker> creator) {
+        LightTaskTracker tracker = INSTANCE_ID_2_TASK_TRACKER.computeIfAbsent(instanceId, creator);
+        if (tracker != null && groupName != null) {
+            // Use compute() for atomic add to group index
+            GROUP_2_INSTANCE_IDS.compute(groupName, (k, set) -> {
+                if (set == null) {
+                    set = ConcurrentHashMap.newKeySet();
+                }
+                set.add(instanceId);
+                return set;
+            });
+        }
+    }
+
+    public static int currentTaskTrackerSize() {
         return INSTANCE_ID_2_TASK_TRACKER.size();
     }
 
+    /**
+     * Get the number of running lightweight task trackers for a specific group.
+     */
+    public static int currentTaskTrackerSizeByGroup(String groupName) {
+        Set<Long> ids = GROUP_2_INSTANCE_IDS.get(groupName);
+        return ids == null ? 0 : ids.size();
+    }
+
+    /**
+     * Clear all tracking state. Called during worker shutdown.
+     */
+    public static void clearAll() {
+        INSTANCE_ID_2_TASK_TRACKER.clear();
+        GROUP_2_INSTANCE_IDS.clear();
+    }
 }

--- a/powerjob-worker/src/main/java/tech/powerjob/worker/core/tracker/task/light/LightTaskTracker.java
+++ b/powerjob-worker/src/main/java/tech/powerjob/worker/core/tracker/task/light/LightTaskTracker.java
@@ -8,6 +8,7 @@ import tech.powerjob.common.SystemInstanceResult;
 import tech.powerjob.common.enums.InstanceStatus;
 import tech.powerjob.common.model.InstanceDetail;
 import tech.powerjob.common.model.InstanceMeta;
+import tech.powerjob.common.model.TaskGroupQuota;
 import tech.powerjob.common.request.ServerQueryInstanceStatusReq;
 import tech.powerjob.common.request.ServerScheduleJobReq;
 import tech.powerjob.common.request.TaskTrackerReportInstanceStatusReq;
@@ -77,6 +78,12 @@ public class LightTaskTracker extends TaskTracker {
      */
     private ProcessResult result;
 
+    /**
+     * Task group for per-group thread pool isolation.
+     * Stored here so removeTaskTracker can find which group this instance belongs to.
+     */
+    private final String taskGroup;
+
     private final AtomicBoolean timeoutFlag = new AtomicBoolean(false);
 
     protected final AtomicBoolean stopFlag = new AtomicBoolean(false);
@@ -86,6 +93,9 @@ public class LightTaskTracker extends TaskTracker {
 
     public LightTaskTracker(ServerScheduleJobReq req, WorkerRuntime workerRuntime) {
         super(req, workerRuntime);
+        // Store task group for per-group tracking and removal
+        String rawGroup = req.getTaskGroup();
+        this.taskGroup = TaskGroupQuota.normalizeTaskGroup(rawGroup);
         try {
             taskContext = constructTaskContext(req, workerRuntime);
             // 等待处理
@@ -109,8 +119,8 @@ public class LightTaskTracker extends TaskTracker {
             } else {
                 timeoutCheckScheduledFuture = null;
             }
-            // 提交任务到线程池
-            processFuture = workerRuntime.getExecutorManager().getLightweightTaskExecutorService().submit(this::processTask);
+            // 提交任务到 group-specific 线程池 (or global pool if no groups configured)
+            processFuture = workerRuntime.getExecutorManager().getGroupLightweightTaskExecutorService(this.taskGroup).submit(this::processTask);
         } catch (Exception e) {
             log.error("[TaskTracker-{}] fail to create TaskTracker for req:{} ", instanceId, req);
             destroy();
@@ -120,11 +130,19 @@ public class LightTaskTracker extends TaskTracker {
     }
 
     /**
+     * Get the task group this tracker belongs to. Used by LightTaskTrackerManager for cleanup.
+     */
+    public String getTaskGroup() {
+        return taskGroup;
+    }
+
+    /**
      * 静态方法创建 TaskTracker
      *
      * @param req 服务端调度任务请求
      * @return LightTaskTracker
      */
+
     public static LightTaskTracker create(ServerScheduleJobReq req, WorkerRuntime workerRuntime) {
         try {
             return new LightTaskTracker(req, workerRuntime);


### PR DESCRIPTION
## Problem Description

PowerJob currently uses a **flat, global thread pool** for all lightweight tasks on a worker. All standalone CRON/API jobs within the same app share a single `lightweightTaskExecutorService` (default max: 1024) and a single `LightTaskTrackerManager`. There is no per-module or per-group isolation.

**Impact:** If Module A's jobs spike (e.g., a burst of payment processing tasks), they consume the entire lightweight thread pool, starving Module B's jobs (e.g., report generation) on the same worker — even if Module B has low volume.

In traditional distributed schedulers, each module or business domain can have its own thread pool with a dedicated quota, preventing cross-module resource contention. This PR brings that capability to PowerJob.

## Scope

**This feature applies exclusively to lightweight tasks** (standalone CRON, API, DailyTimeInterval, Workflow jobs).

**Heavyweight tasks are completely unaffected:**
- Broadcast, Map, MapReduce, FixedRate, FixedDelay jobs continue using the existing global heavyweight pool
- `taskGroup` cannot be set on heavyweight jobs (validation rejects it at creation time)
- Server dispatch uses the original `overload()` check for heavyweight jobs (not the new group-aware check)
- Worker-side heavyweight branch in `TaskTrackerActor` is untouched
- `InstanceStatusCheckService` preserves the original heavyweight early-exit behavior

## Changes

### What this PR does

Adds a new **Task Group** concept — lightweight jobs can be assigned a `taskGroup` string (e.g., `"payments"`, `"reports"`), and each group gets its own **isolated `ThreadPoolExecutor`** on the worker with a configurable quota. The server becomes group-aware when dispatching lightweight tasks, skipping workers whose specific group is at capacity.

### Architecture

\`\`\`
Worker Side (per-group LIGHTWEIGHT thread pools only):
+------------+ +------------+ +------------+
| "payments" | | "reports"  | | "default"  |
| light: 200 | | light: 300 | | light: 524 |
+------------+ +------------+ +------------+
+--------------------------------------------+
| Heavyweight pool (global, UNCHANGED: 64)   |
+--------------------------------------------+

Server Side (group-aware dispatch for lightweight only):
1. Is job lightweight? YES -> group-aware path / NO -> original path
2. [lightweight] Read job.taskGroup, filter by per-group overload
3. [heavyweight] Use original global overload() — zero changes
\`\`\`

### Files changed (16 modified, 2 new)

**New models (powerjob-common):**
- \`TaskGroupQuota.java\` — Group quota configuration (groupName + maxLightweightTaskNum)
- \`TaskGroupStatus.java\` — Runtime group status reported in heartbeat

**DTOs updated (powerjob-common):**
- \`ServerScheduleJobReq\` — added \`taskGroup\` field (only set for lightweight jobs)
- \`WorkerHeartbeat\` — added \`List<TaskGroupStatus> taskGroupStatuses\` (worker to server)
- \`SaveJobInfoRequest\` — added \`taskGroup\` field + validation (rejects taskGroup on heavyweight jobs)
- \`JobInfoDTO\` — added \`taskGroup\` field

**Data model (powerjob-server-persistence):**
- \`JobInfoDO\` — added \`taskGroup\` column (JPA auto-DDL, no migration needed)

**Worker-side (powerjob-worker):**
- \`PowerJobWorkerConfig\` — added \`Map<String, TaskGroupQuota> taskGroupQuotas\`
- \`ExecutorManager\` — creates per-group \`ThreadPoolExecutor\` instances for lightweight tasks, with startup validation, proper shutdown. Heavyweight executor pools untouched.
- \`LightTaskTrackerManager\` — per-group instance tracking via \`GROUP_2_INSTANCE_IDS\`, atomic \`compute()\` operations, \`clearAll()\` for shutdown
- \`LightTaskTracker\` — stores \`taskGroup\` field for O(1) removal lookup, submits to group-specific executor
- \`TaskTrackerActor\` — group-aware capacity check in lightweight branch only. Heavyweight branch completely untouched.
- \`WorkerHealthReporter\` — reports per-group \`TaskGroupStatus\` in heartbeat for lightweight tasks

**Server-side (powerjob-server-core):**
- \`WorkerInfo\` — stores \`taskGroupStatuses\` (volatile for thread safety), \`overloadForGroup()\` with legacy fallback
- \`DispatchService\` — branches by \`isLightweightTask()\`: lightweight uses group-aware \`filterOverloadWorker(workers, taskGroup)\`, heavyweight uses original \`filterOverloadWorker(workers)\` with \`overload()\`. Task group only set on dispatch request for lightweight jobs.
- \`InstanceStatusCheckService\` — per-group overload skip for lightweight tasks; heavyweight tasks preserve original global early-exit behavior via separate \`heavyOverloadFlag\`

**Spring Boot (powerjob-worker-spring-boot-starter):**
- \`PowerJobProperties\` — added \`taskGroupQuotas\` property binding
- \`PowerJobAutoConfiguration\` — maps properties to config

### Configuration example

\`\`\`yaml
powerjob:
  worker:
    max-lightweight-task-num: 1024
    task-group-quotas:
      payments:
        max-lightweight-task-num: 200
      reports:
        max-lightweight-task-num: 300
      default:
        max-lightweight-task-num: 524
\`\`\`

## Heavyweight Job Safety

| Layer | Heavyweight behavior |
|---|---|
| **Job creation** (\`SaveJobInfoRequest.valid()\`) | Rejects \`taskGroup\` on non-STANDALONE or FIXED_RATE/FIXED_DELAY with error |
| **Server dispatch** (\`DispatchService\`) | Uses original \`filterOverloadWorker(workers)\` with \`overload()\` — no group logic |
| **Dispatch request** (\`constructServerScheduleJobReq\`) | \`taskGroup\` left null — never set for heavyweight |
| **Worker actor** (\`TaskTrackerActor\`) | Heavyweight branch untouched — uses global \`maxHeavyweightTaskNum\` |
| **Status check** (\`InstanceStatusCheckService\`) | Uses separate \`heavyOverloadFlag\` for early-exit, preserving original behavior |

## Backward Compatibility

Fully backward compatible. No breaking changes.

| Scenario | Behavior |
|---|---|
| Worker with no \`taskGroupQuotas\` configured | Single flat pool, exactly as before |
| Job with \`taskGroup = null\` | Normalized to \`"default"\` group |
| Old server + new worker | Server ignores \`taskGroupStatuses\`, uses global overload |
| New server + old worker | No group data in heartbeat, falls back to global overload |

## Edge Cases Handled

1. **Unknown group on worker** — falls back to \`"default"\` group with warning log
2. **Worker restart** — \`LightTaskTrackerManager.clearAll()\` called on shutdown to reset static maps
3. **Concurrent add/remove** — \`ConcurrentHashMap.compute()\` for atomic group index operations
4. **Removal lookup** — \`LightTaskTracker\` stores \`taskGroup\` for O(1) reverse lookup
5. **OVERLOAD_FACTOR 1.3x** — applied per group (server stops routing at 100%, worker hard-rejects at 130%)
6. **Null/empty taskGroup** — normalized to \`"default"\` everywhere
7. **Startup validation** — \`"default"\` group required, per-group quota > 0, sum <= maxLightweightTaskNum
8. **Thread safety** — \`WorkerInfo.taskGroupStatuses\` is volatile with snapshot-on-read pattern
9. **All dispatch paths converge** — CRON, API, workflow, retry, timeout all go through \`DispatchService.dispatch()\`
10. **taskGroup on heavyweight job** — rejected at creation time with clear error message

## Testing

- [x] Build succeeds (all 23 modules)
- [x] JPA auto-DDL creates \`task_group\` column on startup
- [x] Per-group executors created with correct thread counts and queue sizes
- [x] Server dispatches contain correct \`taskGroup\` values (payments/reports/default)
- [x] Jobs execute successfully in their respective group pools (status=SUCCEED)
- [x] Worker heartbeat reports per-group status every 10 seconds
- [x] Jobs with \`taskGroup=NULL\` correctly normalized to \`"default"\`
- [x] Tested on remote Linux machine (Ubuntu 24.04, Java 17, MySQL 8.0, PowerJob v5.1.2)

## Affected Versions

Built and tested on PowerJob \`v5.1.2\` (current master).