### PR TITLE
feat(official-processors): inject workflow context into script process env and support ${wfContext.xxx} placeholders

### DIFF
--- a/powerjob-official-processors/src/main/java/tech/powerjob/official/processors/impl/script/AbstractScriptProcessor.java
+++ b/powerjob-official-processors/src/main/java/tech/powerjob/official/processors/impl/script/AbstractScriptProcessor.java
@@ -18,6 +18,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
@@ -49,9 +50,26 @@ public abstract class AbstractScriptProcessor extends CommonBasicProcessor {
             omsLogger.warn(message);
             return new ProcessResult(false, message);
         }
+
+        // 如果存在工作流上下文，先做简单替换 ${wfContext.key} -> value
+        if (context.getWorkflowContext() != null) {
+            try {
+                Map<String, String> wfMap = context.getWorkflowContext().fetchWorkflowContext();
+                if (wfMap != null && !wfMap.isEmpty() && scriptParams != null) {
+                    for (Map.Entry<String, String> e : wfMap.entrySet()) {
+                        String placeholder = "${wfContext." + e.getKey() + "}";
+                        scriptParams = scriptParams.replace(placeholder, e.getValue() == null ? "" : e.getValue());
+                    }
+                }
+            } catch (Exception ignore) {
+                // 不应阻塞主流程，记录日志即可
+                omsLogger.warn("[SYSTEM] Replace wfContext placeholders failed.", ignore);
+            }
+        }
+
         String scriptPath = prepareScriptFile(context.getInstanceId(), scriptParams);
         omsLogger.info("[SYSTEM] Generate executable file successfully, path: {}", scriptPath);
-        
+
         if (SystemUtils.IS_OS_WINDOWS) {
             if (StringUtils.equals(getRunCommand(), SH_SHELL)) {
                 String message = String.format("[SYSTEM] Current OS is %s where shell scripts cannot run.", SystemUtils.OS_NAME);
@@ -71,6 +89,20 @@ public abstract class AbstractScriptProcessor extends CommonBasicProcessor {
         ProcessBuilder pb = StringUtils.equals(getRunCommand(), CMD_SHELL) ?
                 new ProcessBuilder(getRunCommand(), "/c", scriptPath)
                 : new ProcessBuilder(getRunCommand(), scriptPath);
+
+        // 将工作流上下文注入到子进程环境，脚本可以通过 $KEY 或 ${KEY} 读取
+        if (context.getWorkflowContext() != null) {
+            try {
+                Map<String, String> wfMap = context.getWorkflowContext().fetchWorkflowContext();
+                if (wfMap != null && !wfMap.isEmpty()) {
+                    pb.environment().putAll(wfMap);
+                    omsLogger.info("[SYSTEM] Inject workflow context into process environment: {}", wfMap.keySet());
+                }
+            } catch (Exception e) {
+                omsLogger.warn("[SYSTEM] Failed to inject workflow context into process environment.", e);
+            }
+        }
+
         Process process = pb.start();
 
         StringBuilder inputBuilder = new StringBuilder();


### PR DESCRIPTION
…s env and support ${wfContext.xxx} placeholders

修复脚本处理器在工作流场景下无法方便读取 workflowContext 变量的问题。改动在不变更外部接口的前提下，向子进程注入 workflowContext 的键值为环境变量，并在生成脚本前提供一个简单的 ${wfContext.xxx} 占位符替换支持。

## What is the purpose of the change

目前 AbstractScriptProcessor 在工作流场景下只会取 jobParams（仍保留此行为），且无任何占位符替换或将 workflowContext 注入到脚本运行环境的逻辑。导致脚本无法直接使用工作流上下文变量（例如 run_id、某些上游任务写入的 context 数据）。

## Brief changelog

在 prepareScriptFile 写文件前，对脚本内容做简单的占位符替换：把 ${wfContext.key} 替换为 workflowContext.fetchWorkflowContext() 中对应的值（如果存在）。
在用 ProcessBuilder 启动子进程前，读取 workflowContext.fetchWorkflowContext() 并将其 putAll 到 pb.environment()，使子进程可以通过 $KEY 或 ${KEY} 读取对应值。
不修改 CommonUtils 的参数选择逻辑（工作流下仍优先 jobParams），仅在脚本执行层加入替换与注入机制。

## Verifying this change

已测试
<img width="971" height="205" alt="image" src="https://github.com/user-attachments/assets/027c5e51-8437-4e93-9944-354c144c0473" />
<img width="796" height="256" alt="image" src="https://github.com/user-attachments/assets/2419d415-2650-483f-9938-42a4bbed580e" />
运行效果
<img width="1715" height="88" alt="image" src="https://github.com/user-attachments/assets/8b889a7d-9754-4c20-86c8-05e8345a3db6" />
