### PR TITLE
fix(docker): wait for MySQL healthy before starting dependents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@
 # 1. PowerJob 根目录执行：docker-compose up
 # 2. 静静等待服务启动。
 
-version: '3'
 services:
   powerjob-mysql:
     environment:
@@ -16,13 +15,20 @@ services:
     volumes:
       - ./powerjob-data/powerjob-mysql:/var/lib/mysql
     command: --lower_case_table_names=1
+    healthcheck:
+      test: ["CMD-SHELL", "/healthcheck.sh"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 120s
 
   powerjob-server:
     container_name: powerjob-server
     image: powerjob/powerjob-server:latest
     restart: always
     depends_on:
-      - powerjob-mysql
+      powerjob-mysql:
+        condition: service_healthy
     environment:
       JVMOPTIONS: "-Xmx512m"
       PARAMS: "--oms.mongodb.enable=false --spring.datasource.core.jdbc-url=jdbc:mysql://powerjob-mysql:3306/powerjob-daily?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai"
@@ -39,8 +45,10 @@ services:
     image: powerjob/powerjob-worker-samples:latest
     restart: always
     depends_on:
-      - powerjob-mysql
-      - powerjob-server
+      powerjob-mysql:
+        condition: service_healthy
+      powerjob-server:
+        condition: service_started
 #    environment:
 #      PARAMS: "--powerjob.worker.server-address=powerjob-server:7700"
     ports:

--- a/others/dev/docker-compose.yml
+++ b/others/dev/docker-compose.yml
@@ -1,6 +1,5 @@
 # 构建 PowerJob 测试环境
 
-version: '3.7'
 services:
   powerjob-mysql:
     build:
@@ -20,6 +19,12 @@ services:
     volumes:
       - ~/powerjob-data/powerjob-mysql:/var/lib/mysql
     command: --lower_case_table_names=1
+    healthcheck:
+      test: ["CMD-SHELL", "/healthcheck.sh"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 120s
   #  powerjob-mongodb:
   #    image: mongo:latest
   #    container_name: powerjob-mongodb
@@ -44,8 +49,10 @@ services:
     image: powerjob/powerjob-server:test_env
     restart: always
     depends_on:
-      - powerjob-mysql
-    #      - powerjob-mongodb
+      powerjob-mysql:
+        condition: service_healthy
+    #      powerjob-mongodb:
+    #        condition: service_started
     environment:
       PARAMS: "--spring.profiles.active=daily --logging.config=classpath:logback-product.xml --spring.datasource.core.jdbc-url=jdbc:mysql://powerjob-mysql:3306/powerjob-daily?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai --oms.storage.dfs.mysql_series.url=jdbc:mysql://powerjob-mysql:3306/powerjob-daily?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai"
       JVMOPTIONS: "-server -XX:+UseG1GC -Xms768m -Xmx768m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=7 -XX:GCLogFileSize=100M -Xloggc:/root/powerjob/server/gc.log -Dpowerjob.sp-env=trial -Dpowerjob.server.test.user.accounts=powerjob"
@@ -65,8 +72,10 @@ services:
     image: powerjob/powerjob-worker-agent:test_env
     restart: always
     depends_on:
-      - powerjob-mysql
-      - powerjob-server
+      powerjob-mysql:
+        condition: service_healthy
+      powerjob-server:
+        condition: service_started
     ports:
       - "5002:5005"
       - "10002:10000"
@@ -83,8 +92,10 @@ services:
     image: powerjob/powerjob-worker-agent:test_env
     restart: always
     depends_on:
-      - powerjob-mysql
-      - powerjob-server
+      powerjob-mysql:
+        condition: service_healthy
+      powerjob-server:
+        condition: service_started
     ports:
       - "5003:5005"
       - "10003:10000"


### PR DESCRIPTION
## Summary

- Add an explicit MySQL `healthcheck` (using the image's `/healthcheck.sh`) in root and dev `docker-compose.yml`.
- Change MySQL-dependent services to `depends_on: condition: service_healthy` so Compose waits until MySQL is ready, instead of only waiting for the container process to start.
- Remove obsolete Compose `version` keys (Compose V2 ignores them and warns).

Previously, `depends_on: powerjob-mysql` only ensured the container was created/started. `powerjob-server` could still race MySQL initialization and fail (or loop reconnect) until the DB became usable. This aligns compose startup with actual readiness.

Related to #472 (startup ordering for compose). That issue focused on worker waiting for server (`wait-for-it`); this PR covers the **server/worker → MySQL** side via health conditions.

## Test plan

- [x] `docker compose config` validates successfully
- [x] `docker compose up -d` logs show: `powerjob-mysql Started` → `Waiting` → `Healthy` → then `powerjob-server` / workers start
- [x] `powerjob-mysql` reaches `(healthy)`; dependents start only after that
- [x] Fresh data dir: first-time MySQL init still becomes healthy within `start_period` (120s) + retries