### PR TITLE
fix: upgrade fastjson to 1.2.84 to address CVE-2026-16723 (RCE)

### DIFF
--- a/powerjob-client/pom.xml
+++ b/powerjob-client/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <junit.version>5.9.1</junit.version>
         <logback.version>1.2.13</logback.version>
-        <fastjson.version>1.2.83</fastjson.version>
+        <fastjson.version>1.2.84</fastjson.version>
         <powerjob.common.version>5.1.2</powerjob.common.version>
 
         <mvn.shade.plugin.version>3.2.4</mvn.shade.plugin.version>

--- a/powerjob-official-processors/pom.xml
+++ b/powerjob-official-processors/pom.xml
@@ -27,7 +27,7 @@
         <spring.version>5.3.31</spring.version>
 
         <!-- 全部 shade 化，避免依赖冲突 -->
-        <fastjson.version>1.2.83</fastjson.version>
+        <fastjson.version>1.2.84</fastjson.version>
         <okhttp.version>3.14.9</okhttp.version>
         <guava.version>30.1.1-jre</guava.version>
         <commons.io.version>2.11.0</commons.io.version>

--- a/powerjob-server/pom.xml
+++ b/powerjob-server/pom.xml
@@ -43,7 +43,7 @@
         <jgit.version>5.13.2.202306221912-r</jgit.version>
         <mvn.invoker.version>3.0.1</mvn.invoker.version>
         <commons.net.version>3.9.0</commons.net.version>
-        <fastjson.version>1.2.83</fastjson.version>
+        <fastjson.version>1.2.84</fastjson.version>
         <dingding.version>1.0.1</dingding.version>
 
         <!-- skip this module when deploying. -->

--- a/powerjob-worker-samples/pom.xml
+++ b/powerjob-worker-samples/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <springboot.version>2.7.18</springboot.version>
         <powerjob.worker.starter.version>5.1.2</powerjob.worker.starter.version>
-        <fastjson.version>1.2.83</fastjson.version>
+        <fastjson.version>1.2.84</fastjson.version>
         <powerjob.official.processors.version>5.1.2</powerjob.official.processors.version>
 
         <!-- 部署时跳过该module -->


### PR DESCRIPTION
## What

Bump `fastjson.version` from 1.2.83 to 1.2.84 in all four modules that declare it:

- powerjob-server
- powerjob-client
- powerjob-official-processors
- powerjob-worker-samples

## Why

CVE-2026-16723 (GHSA-crf3-v9rr-v7hj) is a critical RCE affecting fastjson 1.2.68 ~ 1.2.83:

- exploitable with AutoType **disabled** (default config)
- no third-party gadget classes required
- specifically targets Spring Boot executable fat-jar deployments, which is exactly how `powerjob-server` ships (`spring-boot-maven-plugin` repackage)

`powerjob-server` 5.1.2 pins fastjson 1.2.83, so the standard build is affected. fastjson 1.2.84 (released 2026-07-29) is the official fix for the 1.x line.

Refs:

- Advisory: https://github.com/alibaba/fastjson2/wiki/Security-Advisory%3A-Remote-Code-Execution-in-fastjson-1.2.68%E2%80%931.2.83
- GHSA: https://github.com/advisories/GHSA-crf3-v9rr-v7hj

## Verification

- `mvn clean install -DskipTests` passes for all modules
- `BOOT-INF/lib/fastjson-1.2.84.jar` confirmed inside the built `powerjob-server-starter` fat jar
- unit tests pass in powerjob-common / powerjob-client / powerjob-official-processors / powerjob-remote / powerjob-worker (H2 persistence)
- no `WriteClassName` / AutoType whitelist usage in the code base, so the hardened parsing in 1.2.84 does not change existing behavior
- integration tests that require a running server / external DB were not run (environment not available locally)

Related: #1187 (fastjson2 migration discussion — the long-term fix; this PR is the minimal security fix for the 1.x line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)